### PR TITLE
[Feature] 모임 모집글 목록 조회 - No Offset 기반, Cursor 기반

### DIFF
--- a/src/main/java/com/momo/config/SecurityConfig.java
+++ b/src/main/java/com/momo/config/SecurityConfig.java
@@ -5,8 +5,10 @@ import com.momo.auth.security.LoginFilter;
 import com.momo.config.constants.EndpointConstants;
 import com.momo.config.token.repository.RefreshTokenRepository;
 import com.momo.user.repository.UserRepository;
+import java.net.http.HttpRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -68,8 +70,10 @@ public class SecurityConfig {
                 EndpointConstants.ROOT,
                 EndpointConstants.USERS_API,
                 EndpointConstants.TOKEN_REISSUE,
-                "/h2-console/**"
+                EndpointConstants.H2
             ).permitAll()
+            .antMatchers(HttpMethod.GET, EndpointConstants.MEETINGS).permitAll()
+            .antMatchers(HttpMethod.POST, EndpointConstants.MEETINGS).authenticated()
             .anyRequest().authenticated()
         )
         .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable())) // 프레임 옵션 비활성화

--- a/src/main/java/com/momo/config/constants/EndpointConstants.java
+++ b/src/main/java/com/momo/config/constants/EndpointConstants.java
@@ -5,4 +5,6 @@ public class EndpointConstants {
   public static final String USERS_API = "/api/v1/users/**";
   public static final String TOKEN_REISSUE = "/token/reissue";
   public static final String H2 = "/h2-console/**";
+  public static final String MEETINGS = "/api/v1/meetings/**";
+
 }

--- a/src/main/java/com/momo/config/constants/ExcludePath.java
+++ b/src/main/java/com/momo/config/constants/ExcludePath.java
@@ -1,0 +1,15 @@
+package com.momo.config.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExcludePath {
+  MEETINGS_LIST("/api/v1/meetings", HttpMethod.GET);
+  // 추후 제외할 경로가 생기면 여기에 추가
+
+  private final String path;
+  private final HttpMethod method;
+}

--- a/src/main/java/com/momo/meeting/constant/FoodCategory.java
+++ b/src/main/java/com/momo/meeting/constant/FoodCategory.java
@@ -1,10 +1,44 @@
 package com.momo.meeting.constant;
 
+import com.momo.meeting.exception.MeetingErrorCode;
+import com.momo.meeting.exception.MeetingException;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum FoodCategory {
-  KOREAN,
-  CHINESE,
-  JAPANESE,
-  WESTERN,
-  DESSERT,
-  OTHER
+  KOREAN("한식"),
+  CHINESE("중식"),
+  JAPANESE("일식"),
+  WESTERN("양식"),
+  DESSERT("디저트"),
+  OTHER("기타");
+
+  private final String description;
+
+  public static Set<String> convertToFoodCategories(String categoryStr) {
+    if (categoryStr == null || categoryStr.isEmpty()) {
+      return new HashSet<>();
+    }
+
+    Set<String> foodCategories = new HashSet<>();
+    String[] categorise = categoryStr.split(",");
+
+    for (String category : categorise) {
+      FoodCategory.getFoodCategoryDescription(category).ifPresent(foodCategories::add);
+    }
+    return foodCategories;
+  }
+
+  private static Optional<String> getFoodCategoryDescription(String category) {
+    try {
+      return Optional.of(FoodCategory.valueOf(category).getDescription());
+    } catch (IllegalArgumentException e) {
+      throw new MeetingException(MeetingErrorCode.INVALID_FOOD_CATEGORY);
+    }
+  }
 }

--- a/src/main/java/com/momo/meeting/constant/MeetingStatus.java
+++ b/src/main/java/com/momo/meeting/constant/MeetingStatus.java
@@ -8,8 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum MeetingStatus {
 
   RECRUITING("모집 중"),
-  CLOSED("모집 완료"),
-  EXPIRED("기간 만료");
+  CLOSED("모집 완료");
 
   private final String description;
 }

--- a/src/main/java/com/momo/meeting/controller/MeetingController.java
+++ b/src/main/java/com/momo/meeting/controller/MeetingController.java
@@ -1,17 +1,22 @@
 package com.momo.meeting.controller;
 
-import com.momo.meeting.dto.MeetingCreateRequest;
-import com.momo.meeting.dto.MeetingCreateResponse;
+import com.momo.meeting.dto.create.MeetingCreateRequest;
+import com.momo.meeting.dto.create.MeetingCreateResponse;
+import com.momo.meeting.dto.MeetingListReadRequest;
+import com.momo.meeting.dto.MeetingListReadResponse;
 import com.momo.meeting.service.MeetingService;
 import com.momo.user.dto.CustomUserDetails;
 import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,6 +28,7 @@ public class MeetingController {
 
   @PostMapping
   public ResponseEntity<MeetingCreateResponse> createMeeting(
+      // TODO: 사용자 위치 정보 필요
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @Valid @RequestBody MeetingCreateRequest request
   ) {
@@ -33,5 +39,18 @@ public class MeetingController {
     return ResponseEntity
         .created(URI.create("api/posts/" + response.getId()))
         .body(response);
+  }
+
+  @GetMapping
+  public ResponseEntity<MeetingListReadResponse> getNearbyMeetings(
+      @RequestParam @Range(min = -90, max = 90) double latitude,
+      @RequestParam @Range(min = -180, max = 180) double longitude,
+      @RequestParam(required = false) Long lastId,
+      @RequestParam(required = false) Double lastDistance,
+      @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int pageSize
+  ) {
+    MeetingListReadRequest request = MeetingListReadRequest
+        .createCursorRequest(latitude, longitude, lastId, lastDistance, pageSize);
+    return ResponseEntity.ok(meetingService.getNearbyMeetings(request));
   }
 }

--- a/src/main/java/com/momo/meeting/dto/MeetingCursor.java
+++ b/src/main/java/com/momo/meeting/dto/MeetingCursor.java
@@ -1,0 +1,19 @@
+package com.momo.meeting.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MeetingCursor {
+
+  private Long id;
+  private Double distance;
+
+  public static MeetingCursor of(Long id, Double distance) {
+    return MeetingCursor.builder()
+        .id(id)
+        .distance(distance)
+        .build();
+  }
+}

--- a/src/main/java/com/momo/meeting/dto/MeetingDto.java
+++ b/src/main/java/com/momo/meeting/dto/MeetingDto.java
@@ -1,0 +1,65 @@
+package com.momo.meeting.dto;
+
+import com.momo.meeting.constant.FoodCategory;
+import com.momo.meeting.exception.MeetingErrorCode;
+import com.momo.meeting.exception.MeetingException;
+import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Builder
+@ToString
+public class MeetingDto {
+
+  private Long id;
+  private String title;
+  private Long locationId;
+  private Double latitude;
+  private Double longitude;
+  private String address;
+  private LocalDateTime meetingDateTime;
+  private Integer maxCount;
+  private Integer approvedCount;
+  private Set<String> category;
+  private String thumbnailUrl;
+
+  public static List<MeetingDto> convertToMeetingDtos(
+      List<MeetingToMeetingDtoProjection> meetingProjections
+  ) {
+    List<MeetingDto> meetingDtos = new ArrayList<>();
+    for (MeetingToMeetingDtoProjection meetingProjection : meetingProjections) {
+      MeetingDto meetingDto = MeetingDto.from(meetingProjection);
+      meetingDtos.add(meetingDto);
+    }
+    return meetingDtos;
+  }
+
+  public static MeetingDto from(MeetingToMeetingDtoProjection meeting) {
+    Set<String> foodCategories = FoodCategory.convertToFoodCategories(meeting.getCategory());
+    return MeetingDto.builder()
+        .id(meeting.getId())
+        .title(meeting.getTitle())
+        .locationId(meeting.getLocationId())
+        .latitude(meeting.getLatitude())
+        .longitude(meeting.getLongitude())
+        .address(meeting.getAddress())
+        .meetingDateTime(meeting.getMeetingDateTime().truncatedTo(ChronoUnit.MINUTES))
+        .maxCount(meeting.getMaxCount())
+        .approvedCount(meeting.getApprovedCount())
+        .category(foodCategories)
+        .thumbnailUrl(meeting.getThumbnailUrl())
+        .build();
+  }
+}

--- a/src/main/java/com/momo/meeting/dto/MeetingListReadRequest.java
+++ b/src/main/java/com/momo/meeting/dto/MeetingListReadRequest.java
@@ -1,0 +1,45 @@
+package com.momo.meeting.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MeetingListReadRequest {
+
+  private static final Long DEFAULT_LAST_ID = 0L;
+  private static final double DEFAULT_RADIUS = 3000;
+
+  private double userLatitude;
+  private double userLongitude;
+  private double radius;
+  private MeetingCursor meetingCursor;
+  private int pageSize;
+
+  public static MeetingListReadRequest createCursorRequest(
+      double userLatitude,
+      double userLongitude,
+      Long lastId,
+      Double lastDistance,
+      int pageSize
+  ) {
+    lastId = lastId == null ? DEFAULT_LAST_ID : lastId;
+    lastDistance = lastDistance == null ? Double.MIN_VALUE : lastDistance;
+
+    return MeetingListReadRequest.builder()
+        .userLatitude(userLatitude)
+        .userLongitude(userLongitude)
+        .radius(DEFAULT_RADIUS)
+        .meetingCursor(MeetingCursor.of(lastId, lastDistance))
+        .pageSize(pageSize)
+        .build();
+  }
+
+  public Long getCursorId(){
+    return meetingCursor.getId();
+  }
+
+  public Double getCursorDistance(){
+    return meetingCursor.getDistance();
+  }
+}

--- a/src/main/java/com/momo/meeting/dto/MeetingListReadResponse.java
+++ b/src/main/java/com/momo/meeting/dto/MeetingListReadResponse.java
@@ -1,0 +1,29 @@
+package com.momo.meeting.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MeetingListReadResponse {
+
+  private List<MeetingDto> meetings;
+  private boolean hasNext;
+  private MeetingCursor cursor;
+
+  public static MeetingListReadResponse of(
+      List<MeetingDto> meetings,
+      MeetingCursor meetingCursor,
+      int pageSize
+  ) {
+    boolean hasNext = meetings.size() > pageSize;
+    MeetingCursor nextCursor = hasNext ? meetingCursor : null;
+
+    return MeetingListReadResponse.builder()
+        .meetings(meetings)
+        .hasNext(hasNext)
+        .cursor(nextCursor)
+        .build();
+  }
+}

--- a/src/main/java/com/momo/meeting/dto/create/MeetingCreateRequest.java
+++ b/src/main/java/com/momo/meeting/dto/create/MeetingCreateRequest.java
@@ -1,4 +1,4 @@
-package com.momo.meeting.dto;
+package com.momo.meeting.dto.create;
 
 import com.momo.meeting.constant.FoodCategory;
 import com.momo.meeting.constant.MeetingStatus;

--- a/src/main/java/com/momo/meeting/dto/create/MeetingCreateRequest.java
+++ b/src/main/java/com/momo/meeting/dto/create/MeetingCreateRequest.java
@@ -27,8 +27,17 @@ public class MeetingCreateRequest {
   @Future(message = "모임 날짜는 현재 시간 이후로 선택해주세요.")
   private LocalDateTime meetingDateTime;
 
-  @NotNull(message = "모임 장소를 입력해주세요.")
+  @NotNull(message = "위치 아이디 누락")
   private Long locationId;
+
+  @NotNull(message = "위도 누락")
+  private Double latitude;
+
+  @NotNull(message = "경도 누락")
+  private Double longitude;
+
+  @NotNull(message = "주소 누락")
+  private String address;
 
   @Min(value = 2, message = "모임 인원은 2명 이상이어야 합니다.")
   private Integer maxCount;
@@ -46,11 +55,14 @@ public class MeetingCreateRequest {
     return Meeting.builder()
         .user(user)
         .title(request.getTitle())
+        .locationId(request.getLocationId())
+        .latitude(request.getLatitude())
+        .longitude(request.getLongitude())
+        .address(request.getAddress())
         .meetingDateTime(request.getMeetingDateTime())
         .approvedCount(1)
         .maxCount(request.getMaxCount())
-        .locationId(request.getLocationId())
-        .categories(request.getCategories())
+        .category(request.getCategories())
         .content(request.getContent())
         .thumbnailUrl(request.getThumbnailUrl())
         .meetingStatus(MeetingStatus.RECRUITING)

--- a/src/main/java/com/momo/meeting/dto/create/MeetingCreateResponse.java
+++ b/src/main/java/com/momo/meeting/dto/create/MeetingCreateResponse.java
@@ -1,4 +1,4 @@
-package com.momo.meeting.dto;
+package com.momo.meeting.dto.create;
 
 import com.momo.meeting.constant.FoodCategory;
 import com.momo.meeting.constant.MeetingStatus;

--- a/src/main/java/com/momo/meeting/dto/create/MeetingCreateResponse.java
+++ b/src/main/java/com/momo/meeting/dto/create/MeetingCreateResponse.java
@@ -14,10 +14,13 @@ public class MeetingCreateResponse {
 
   private Long id;
   private String title;
+  private Long locationId;
+  private Double latitude;
+  private Double longitude;
+  private String address;
   private LocalDateTime meetingDateTime;
   private Integer approvedCount;
   private Integer maxCount;
-  private Long locationId;
   private Set<FoodCategory> categories;
   private String content;
   private String thumbnailUrl;
@@ -27,11 +30,14 @@ public class MeetingCreateResponse {
     return MeetingCreateResponse.builder()
         .id(meeting.getId())
         .title(meeting.getTitle())
+        .locationId(meeting.getLocationId())
+        .latitude(meeting.getLatitude())
+        .longitude(meeting.getLongitude())
+        .address(meeting.getAddress())
         .meetingDateTime(meeting.getMeetingDateTime())
         .approvedCount(meeting.getApprovedCount())
         .maxCount(meeting.getMaxCount())
-        .locationId(meeting.getLocationId())
-        .categories(meeting.getCategories())
+        .categories(meeting.getCategory())
         .content(meeting.getContent())
         .thumbnailUrl(meeting.getThumbnailUrl())
         .meetingStatus(meeting.getMeetingStatus())

--- a/src/main/java/com/momo/meeting/entity/Meeting.java
+++ b/src/main/java/com/momo/meeting/entity/Meeting.java
@@ -17,12 +17,16 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Meeting extends BaseEntity {
 
   @Id
@@ -37,20 +41,29 @@ public class Meeting extends BaseEntity {
   private String title;
 
   @Column(nullable = false)
-  private LocalDateTime meetingDateTime;
+  private Long locationId;
 
   @Column(nullable = false)
-  private Integer approvedCount;
+  private Double latitude;
+
+  @Column(nullable = false)
+  private Double longitude;
+
+  @Column(nullable = false)
+  private String address;
+
+  @Column(nullable = false)
+  private LocalDateTime meetingDateTime;
 
   @Column(nullable = false)
   private Integer maxCount;
 
   @Column(nullable = false)
-  private Long locationId;
+  private Integer approvedCount;
 
   @ElementCollection // 기본적으로 지연로딩
   @Enumerated(EnumType.STRING)
-  private Set<FoodCategory> categories;
+  private Set<FoodCategory> category;
 
   @Column(nullable = false, length = 600)
   private String content;

--- a/src/main/java/com/momo/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/momo/meeting/exception/MeetingErrorCode.java
@@ -11,7 +11,8 @@ public enum MeetingErrorCode {
   DAILY_POSTING_LIMIT_EXCEEDED(
       "하루 포스팅 개수 제한을 초과하였습니다.", HttpStatus.TOO_MANY_REQUESTS),
   INVALID_MEETING_DATE_TIME(
-      "유효한 모임 시간이 아닙니다.", HttpStatus.BAD_REQUEST);
+      "유효한 모임 시간이 아닙니다.", HttpStatus.BAD_REQUEST),
+  INVALID_FOOD_CATEGORY("유효한 음식 카테고리가 아닙니다.", HttpStatus.BAD_REQUEST);
 
   private final String message;
   private final HttpStatus status;

--- a/src/main/java/com/momo/meeting/projection/MeetingToMeetingDtoProjection.java
+++ b/src/main/java/com/momo/meeting/projection/MeetingToMeetingDtoProjection.java
@@ -1,0 +1,30 @@
+package com.momo.meeting.projection;
+
+import java.time.LocalDateTime;
+
+public interface MeetingToMeetingDtoProjection {
+
+  Long getId();
+
+  String getTitle();
+
+  Long getLocationId();
+
+  Double getLatitude();
+
+  Double getLongitude();
+
+  String getAddress();
+
+  LocalDateTime getMeetingDateTime();
+
+  Integer getMaxCount();
+
+  Integer getApprovedCount();
+
+  String getCategory();
+
+  String getThumbnailUrl();
+
+  Double getDistance();
+}

--- a/src/main/java/com/momo/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/momo/meeting/repository/MeetingRepository.java
@@ -1,12 +1,112 @@
 package com.momo.meeting.repository;
 
 import com.momo.meeting.entity.Meeting;
+import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
-  int countByUser_IdAndCreatedAtBetween(Long userId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+  int countByUser_IdAndCreatedAtBetween(
+      Long userId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+  @Query(value =
+      "SELECT "
+          + "dm.id as id, "
+          + "dm.title as title, "
+          + "dm.location_id as locationId, "
+          + "dm.latitude as latitude, "
+          + "dm.longitude as longitude, "
+          + "dm.address as address, "
+          + "dm.meeting_date_time as meetingDateTime, "
+          + "dm.max_count as maxCount, "
+          + "dm.approved_count as approvedCount, "
+          + "dm.thumbnail_url as thumbnailUrl, "
+          + "("
+          + "  SELECT GROUP_CONCAT(mc.category) "
+          + "  FROM meeting_category mc "
+          + "  WHERE mc.meeting_id = dm.id "
+          + ") as category, "
+          + "dm.distance as distance "
+          + "FROM ("
+          + "  SELECT m.id, m.title, m.location_id, m.latitude, m.longitude, m.address, "
+          + "  m.meeting_date_time, m.max_count, m.approved_count, m.thumbnail_url, "
+          + "    ST_Distance_Sphere( "
+          + "        POINT(:userLongitude, :userLatitude), "
+          + "        POINT(m.longitude, m.latitude) "
+          + "    ) as distance "
+          + "  FROM meeting m "
+          + "  WHERE m.meeting_status = 'RECRUITING' "
+          + ") dm "
+          + "WHERE dm.distance <= :radius "
+          + "AND ("
+          + "  dm.distance > :lastDistance "
+          + "  OR (dm.distance = :lastDistance AND dm.id > :lastId) "
+          + ")"
+          + "ORDER BY dm.distance ASC, dm.id ASC "
+          + "LIMIT :pageSize",
+      nativeQuery = true)
+  List<MeetingToMeetingDtoProjection> findNearbyMeetingsWithCursor(
+      @Param("userLatitude") double userLatitude,
+      @Param("userLongitude") double userLongitude,
+      @Param("radius") double radius,
+      @Param("lastId") Long lastId,
+      @Param("lastDistance") double lastDistance,
+      @Param("pageSize") int pageSize
+  );
+
+  /*@Query(value =
+      "SELECT m.id as id, "
+          + "m.title as title, "
+          + "m.location_id as locationId, "
+          + "m.latitude as latitude, "
+          + "m.longitude as longitude, "
+          + "m.address as address, "
+          + "m.meeting_date_time as meetingDateTime, "
+          + "m.max_count as maxCount, "
+          + "m.approved_count as approvedCount, "
+          + "m.thumbnail_url as thumbnailUrl, "
+          + "GROUP_CONCAT(DISTINCT mc.category) as category, "
+          + "ST_Distance_Sphere("
+          + "    POINT(:userLongitude, :userLatitude), "
+          + "    POINT(m.longitude, m.latitude)"
+          + ") as distance "
+          + "FROM meeting m "
+          + "LEFT JOIN meeting_category mc ON m.id = mc.meeting_id "
+          + "WHERE m.meeting_status = 'RECRUITING' "
+          + "AND ST_Distance_Sphere("
+          + "    POINT(:userLongitude, :userLatitude), "
+          + "    POINT(m.longitude, m.latitude)"
+          + ") <= :radius "
+          + "AND ("
+          + "    ST_Distance_Sphere("
+          + "        POINT(:userLongitude, :userLatitude), "
+          + "        POINT(m.longitude, m.latitude)"
+          + "    ) > :lastDistance "
+          + "    OR ("
+          + "        ST_Distance_Sphere("
+          + "            POINT(:userLongitude, :userLatitude), "
+          + "            POINT(m.longitude, m.latitude)"
+          + "        ) = :lastDistance "
+          + "    AND m.id > :lastId)"
+          + ") "
+          + "GROUP BY m.id, m.title, m.location_id, m.latitude, m.longitude, "
+          + "        m.address, m.meeting_date_time, m.max_count, m.approved_count, "
+          + "        m.thumbnail_url "
+          + "ORDER BY distance ASC, m.id ASC "
+          + "LIMIT :pageSize",
+      nativeQuery = true)
+  List<MeetingToMeetingDtoProjection> findNearbyMeetingsWithCursor(
+      @Param("userLatitude") double userLatitude,
+      @Param("userLongitude") double userLongitude,
+      @Param("radius") double radius,
+      @Param("lastId") Long lastId,
+      @Param("lastDistance") double lastDistance,
+      @Param("pageSize") int pageSize
+  );*/
 }

--- a/src/main/java/com/momo/meeting/service/MeetingService.java
+++ b/src/main/java/com/momo/meeting/service/MeetingService.java
@@ -1,16 +1,23 @@
 package com.momo.meeting.service;
 
-
-import com.momo.meeting.dto.MeetingCreateRequest;
-import com.momo.meeting.dto.MeetingCreateResponse;
+import com.momo.meeting.dto.MeetingCursor;
+import com.momo.meeting.dto.create.MeetingCreateRequest;
+import com.momo.meeting.dto.create.MeetingCreateResponse;
+import com.momo.meeting.dto.MeetingListReadRequest;
+import com.momo.meeting.dto.MeetingListReadResponse;
+import com.momo.meeting.dto.MeetingDto;
+import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
 import com.momo.meeting.validator.MeetingValidator;
 import com.momo.user.entity.User;
 import com.momo.meeting.entity.Meeting;
 import com.momo.meeting.repository.MeetingRepository;
-
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MeetingService {
@@ -18,6 +25,7 @@ public class MeetingService {
   private final MeetingRepository meetingRepository;
   private final MeetingValidator meetingValidator;
 
+  @Transactional
   public MeetingCreateResponse createMeeting(User user, MeetingCreateRequest request) {
     meetingValidator.validateForMeetingCreation(user.getId(), request.getMeetingDateTime());
 
@@ -25,5 +33,52 @@ public class MeetingService {
     Meeting saved = meetingRepository.save(meeting);
 
     return MeetingCreateResponse.from(saved);
+  }
+
+  @Transactional(readOnly = true)
+  public MeetingListReadResponse getNearbyMeetings(MeetingListReadRequest request) {
+    List<MeetingToMeetingDtoProjection> meetingProjections = getMeetingList(request);
+
+    return MeetingListReadResponse.of(
+        MeetingDto.convertToMeetingDtos(meetingProjections),
+        createCursor(meetingProjections),
+        request.getPageSize());
+  }
+
+  private List<MeetingToMeetingDtoProjection> getMeetingList(
+      MeetingListReadRequest request
+  ) {
+    return meetingRepository.findNearbyMeetingsWithCursor(
+        request.getUserLatitude(),
+        request.getUserLongitude(),
+        request.getRadius(),
+        request.getCursorId(),
+        request.getCursorDistance(),
+        request.getPageSize() + 1 // 다음 페이지 존재 여부를 알기 위해 + 1
+    );
+  }
+
+  private MeetingCursor createCursor(List<MeetingToMeetingDtoProjection> meetingProjections) {
+    MeetingToMeetingDtoProjection lastProjection = meetingProjections.get(
+        meetingProjections.size() - 1);
+    return MeetingCursor.of(lastProjection.getId(), lastProjection.getDistance());
+  }
+
+  private void logMeetingListInfo(List<MeetingToMeetingDtoProjection> meetingProjections) {
+    int i = 1;
+    for (MeetingToMeetingDtoProjection meeting : meetingProjections) {
+      log.info("{}번째 데이터: ", i++);
+      log.info("getId : {}", meeting.getId());
+      log.info("getTitle : {}", meeting.getTitle());
+      log.info("getLocationId : {}", meeting.getLocationId());
+      log.info("getLatitude : {}", meeting.getLatitude());
+      log.info("getLongitude : {}", meeting.getLongitude());
+      log.info("getAddress : {}", meeting.getAddress());
+      log.info("getMeetingDateTime : {}", meeting.getMeetingDateTime());
+      log.info("getMaxCount : {}", meeting.getMaxCount());
+      log.info("getApprovedCount : {}", meeting.getApprovedCount());
+      log.info("getCategory : {}", meeting.getCategory());
+      log.info("getThumbnailUrl : {}\n", meeting.getThumbnailUrl());
+    }
   }
 }

--- a/src/main/java/com/momo/profile/controller/ProfileController.java
+++ b/src/main/java/com/momo/profile/controller/ProfileController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/v1/profile")
+@RequestMapping("/api/v1/profiles")
 @RequiredArgsConstructor
 public class ProfileController {
 

--- a/src/main/java/com/momo/profile/service/ProfileService.java
+++ b/src/main/java/com/momo/profile/service/ProfileService.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -24,6 +25,7 @@ public class ProfileService {
   private final ProfileRepository profileRepository;
   private final ProfileImageService profileImageService;
 
+  @Transactional
   public ProfileCreateResponse createProfile(
       User user,
       ProfileCreateRequest request,

--- a/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
@@ -2,6 +2,9 @@ package com.momo.meeting.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -11,15 +14,20 @@ import static org.mockito.Mockito.when;
 
 import com.momo.meeting.constant.FoodCategory;
 import com.momo.meeting.constant.MeetingStatus;
-import com.momo.meeting.dto.MeetingCreateRequest;
-import com.momo.meeting.dto.MeetingCreateResponse;
+import com.momo.meeting.dto.MeetingCursor;
+import com.momo.meeting.dto.MeetingDto;
+import com.momo.meeting.dto.MeetingListReadRequest;
+import com.momo.meeting.dto.MeetingListReadResponse;
+import com.momo.meeting.dto.create.MeetingCreateRequest;
+import com.momo.meeting.dto.create.MeetingCreateResponse;
 import com.momo.meeting.entity.Meeting;
-import com.momo.meeting.exception.MeetingErrorCode;
-import com.momo.meeting.exception.MeetingException;
+import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
 import com.momo.meeting.repository.MeetingRepository;
 import com.momo.meeting.validator.MeetingValidator;
 import com.momo.user.entity.User;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -103,7 +111,7 @@ class MeetingServiceTest {
         .approvedCount(1)
         .maxCount(request.getMaxCount())
         .locationId(request.getLocationId())
-        .categories(request.getCategories())
+        //.categories(request.getCategories())
         .content(request.getContent())
         .thumbnailUrl(request.getThumbnailUrl())
         .meetingStatus(MeetingStatus.RECRUITING)
@@ -120,5 +128,112 @@ class MeetingServiceTest {
         .content("테스트 내용")
         .thumbnailUrl("test-thumbnail-url.jpg")
         .build();
+  }
+
+  private static final Double userLatitude = 37.502942;
+  private static final Double userLongitude = 126.947629;
+  private static final int TEST_PAGE_SIZE = 10;
+
+  @Test
+  @DisplayName("모집글 목록 조회 - 성공")
+  void getNearbyMeetings_Success() {
+    // given
+    MeetingListReadRequest request = createaMeetingListReadRequest();
+    List<MeetingToMeetingDtoProjection> mockProjections = createMockProjections();
+
+    when(meetingRepository.findNearbyMeetingsWithCursor(
+        request.getUserLatitude(),
+        request.getUserLongitude(),
+        request.getRadius(),
+        request.getCursorId(),
+        request.getCursorDistance(),
+        request.getPageSize() + 1
+    )).thenReturn(mockProjections);
+
+    // when
+    MeetingListReadResponse response = meetingService.getNearbyMeetings(request);
+
+    // then
+    assertEquals(TEST_PAGE_SIZE + 1, response.getMeetings().size());
+    verifyMeetingDtos(response.getMeetings());
+    assertTrue(response.isHasNext());
+
+    verifyCursor(response);
+
+    verify(meetingRepository).findNearbyMeetingsWithCursor(
+        request.getUserLatitude(),
+        request.getUserLongitude(),
+        request.getRadius(),
+        request.getCursorId(),
+        request.getCursorDistance(),
+        request.getPageSize() + 1
+    );
+  }
+
+  private static MeetingListReadRequest createaMeetingListReadRequest() {
+    return MeetingListReadRequest.createCursorRequest(
+        userLatitude,
+        userLongitude,
+        null,
+        null,
+        TEST_PAGE_SIZE
+    );
+  }
+
+  private List<MeetingToMeetingDtoProjection> createMockProjections() {
+    List<MeetingToMeetingDtoProjection> projections = new ArrayList<>();
+    // 모의 데이터 생성 로직
+    for (int i = 1; i <= TEST_PAGE_SIZE + 1; i++) { // pageSize + 1
+      createMockProjection(projections, i);
+    }
+    return projections;
+  }
+
+  private static void createMockProjection(List<MeetingToMeetingDtoProjection> projections, int i) {
+    MeetingToMeetingDtoProjection projection = mock(MeetingToMeetingDtoProjection.class);
+    when(projection.getId()).thenReturn((long) i);
+    when(projection.getTitle()).thenReturn("title" + i);
+    when(projection.getLocationId()).thenReturn((long) i);
+    when(projection.getLatitude()).thenReturn((double) i);
+    when(projection.getLongitude()).thenReturn((double) i);
+    when(projection.getAddress()).thenReturn("address" + i);
+    when(projection.getMeetingDateTime())
+        .thenReturn(LocalDateTime.of(2025, 1, 23, 3, 0)
+            .plusDays(i));
+    when(projection.getMaxCount()).thenReturn(2 + i);
+    when(projection.getApprovedCount()).thenReturn(1 + i);
+    when(projection.getCategory()).thenReturn("KOREAN,JAPANESE");
+    when(projection.getThumbnailUrl()).thenReturn("test-url" + i + ".jpg");
+    projections.add(projection);
+  }
+
+  private static void verifyMeetingDtos(List<MeetingDto> meetingDtos) {
+    for (int i = 1; i < TEST_PAGE_SIZE + 1; i++) {
+      verifyMeetingDto(meetingDtos, i);
+    }
+  }
+
+  private static void verifyMeetingDto(List<MeetingDto> meetingDtos, int i) {
+    MeetingDto meetingDto = meetingDtos.get(i - 1);
+    assertEquals(i, meetingDto.getId());
+    assertEquals("title" + i, meetingDto.getTitle());
+    assertEquals(i, meetingDto.getLocationId());
+    assertEquals(i, meetingDto.getLatitude());
+    assertEquals(i, meetingDto.getLongitude());
+    assertEquals("address" + i, meetingDto.getAddress());
+    assertEquals(LocalDateTime.of(2025, 1, 23, 3, 0)
+            .plusDays(i),
+        meetingDto.getMeetingDateTime());
+    assertEquals(2 + i, meetingDto.getMaxCount());
+    assertEquals(1 + i, meetingDto.getApprovedCount());
+    assertEquals(Set.of("한식", "일식"), meetingDto.getCategory());
+    assertEquals("test-url" + i + ".jpg", meetingDto.getThumbnailUrl());
+  }
+
+  private static void verifyCursor(MeetingListReadResponse response) {
+    List<MeetingDto> meetingDtos = response.getMeetings();
+    MeetingDto meetingDto = meetingDtos.get(meetingDtos.size() - 1);
+    MeetingCursor cursor = response.getCursor();
+    assertEquals(cursor.getId(), meetingDto.getId());
   }
 }

--- a/src/test/java/com/momo/meeting/validator/MeetingValidatorTest.java
+++ b/src/test/java/com/momo/meeting/validator/MeetingValidatorTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.momo.meeting.constant.FoodCategory;
-import com.momo.meeting.dto.MeetingCreateRequest;
+import com.momo.meeting.dto.create.MeetingCreateRequest;
 import com.momo.meeting.exception.MeetingErrorCode;
 import com.momo.meeting.exception.MeetingException;
 import com.momo.meeting.repository.MeetingRepository;


### PR DESCRIPTION
## 📌 관련 이슈
- close #33 

## 📝 변경 사항
### AS-IS
- 모임 목록 기능 부재
- offset 기반으로 구현 시, 목록을 내릴 수록 부하가 심해짐

### TO-BE
- 모임 목록 조회 요청 받을 GET 엔드포인트 구현
  - 사용자의 위치(위도 경도), 커서(lastId, lastDistance), 페이지 크기를 매개변수로 받음
  - 초기 요청 시에는 커서값이 모두 null, 이후 요청부터는 마지막 모집글의 id와 distance를 요청으로 받고, 해당 커서를 기준으로 이후 모집글부터 조회
- 사용자의 위치와 각 모집글의 위치를 기반으로, 사용자로부터 가까운 순서대로 정렬하여 반환하는 네이티브 기반 쿼리 메서드 구현
  - Meeting Entity의 전체 정보가 아닌, Proejction을 통해 필요한 정보를 가져오도록 함
- 반환값에는 요청한 페이지 수만큼의 모집글 정보, 다음 페이지 존재 여부, 커서 정보가 포함

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
![read-meetingList_1](https://github.com/user-attachments/assets/f0471971-54f3-4ed6-a4ed-1f6d520ce54a)
- 처음 요청 시에는 lastId, lastDistance는 null
![read-meetingList_2](https://github.com/user-attachments/assets/7cc5087c-3bd0-4f2f-99f7-cad9f46abe34)
- 이후 요청부터는 이전 응답값의 마지막 모집글의 id와 distance를 요청에 포함

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.