### PR TITLE
Feature/41/카카오연동해제

### DIFF
--- a/src/main/java/com/momo/auth/controller/KakaoDeleteController.java
+++ b/src/main/java/com/momo/auth/controller/KakaoDeleteController.java
@@ -1,0 +1,114 @@
+package com.momo.auth.controller;
+
+import com.momo.config.JWTUtil;
+import com.momo.config.token.repository.RefreshTokenRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@RestController
+@RequestMapping
+public class KakaoDeleteController {
+
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final JWTUtil jwtUtil;
+  private final RestTemplate restTemplate;
+
+  public KakaoDeleteController(JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository, RestTemplate restTemplate) {
+    this.jwtUtil = jwtUtil;
+    this.refreshTokenRepository = refreshTokenRepository;
+    this.restTemplate = restTemplate;
+  }
+
+  @DeleteMapping("/api/v1/kakao/delete")
+  @Transactional
+  public ResponseEntity<?> kakaoDelete(HttpServletRequest request, HttpServletResponse response) {
+    // Authorization 헤더에서 Bearer 토큰 추출
+    String accessToken = extractAccessTokenFromAuthorizationHeader(request);
+
+    // 엑세스 토큰이 없으면 에러 반환
+    if (accessToken == null) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Access token is missing");
+    }
+
+    try {
+      // 카카오 회원 탈퇴 처리
+      deleteKakaoUser(accessToken);
+
+      // 카카오 회원 탈퇴 후 쿠키 삭제 및 DB에서 Refresh Token 삭제
+      clearRefreshCookie(response);
+      String email = "kakao_user_email";  // 카카오 이메일을 어떻게 가져올지에 대한 추가 로직 필요
+      refreshTokenRepository.deleteByEmail(email);
+
+      return ResponseEntity.ok("Kakao account deletion completed successfully.");
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to delete Kakao account");
+    }
+  }
+
+  private void deleteKakaoUser(String accessToken) {
+    String kakaoDeleteUrl = "https://kapi.kakao.com/v1/user/unlink";
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "Bearer " + accessToken);  // 카카오 로그인 시 받은 엑세스 토큰 사용
+
+    HttpEntity<String> entity = new HttpEntity<>(headers);
+    try {
+      ResponseEntity<String> response = restTemplate.exchange(kakaoDeleteUrl, HttpMethod.POST, entity, String.class);
+
+      // 카카오 API 응답 상태 코드 및 본문을 로그로 출력
+      log.debug("Kakao delete API response status: {}", response.getStatusCode());
+      log.debug("Kakao delete API response body: {}", response.getBody());
+
+      if (response.getStatusCode() != HttpStatus.OK) {
+        throw new RuntimeException("Failed to delete Kakao account. Status: " + response.getStatusCode() + ", Body: " + response.getBody());
+      }
+    } catch (Exception e) {
+      log.error("Error occurred while calling Kakao delete API: ", e);
+      throw new RuntimeException("Error occurred while calling Kakao delete API: " + e.getMessage(), e);
+    }
+  }
+
+  private String extractAccessTokenFromAuthorizationHeader(HttpServletRequest request) {
+    String authorizationHeader = request.getHeader("Authorization");
+    if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+      return authorizationHeader.substring(7); // "Bearer "를 제외한 토큰 값 추출
+    }
+    return null;
+  }
+
+  // 쿠키에서 Refresh 토큰 추출
+  private String extractRefreshTokenFromCookies(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if ("refresh".equals(cookie.getName())) {
+          return cookie.getValue(); // 쿠키에서 refresh 토큰 추출
+        }
+      }
+    }
+    return null;
+  }
+
+  // 쿠키 삭제 메서드
+  private void clearRefreshCookie(HttpServletResponse response) {
+    Cookie cookie = new Cookie("refresh", null);
+    cookie.setMaxAge(0);
+    cookie.setHttpOnly(true);
+    cookie.setPath("/");
+    response.addCookie(cookie);
+  }
+}

--- a/src/main/java/com/momo/auth/controller/KakaoDeleteController.java
+++ b/src/main/java/com/momo/auth/controller/KakaoDeleteController.java
@@ -53,9 +53,9 @@ public class KakaoDeleteController {
       String email = "kakao_user_email";  // 카카오 이메일을 어떻게 가져올지에 대한 추가 로직 필요
       refreshTokenRepository.deleteByEmail(email);
 
-      return ResponseEntity.ok("Kakao account deletion completed successfully.");
+      return ResponseEntity.ok("카카오 계정 연동이 해제되었습니다.");
     } catch (Exception e) {
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to delete Kakao account");
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("인증에 실패했습니다.");
     }
   }
 

--- a/src/main/java/com/momo/auth/controller/KakaoLogoutController.java
+++ b/src/main/java/com/momo/auth/controller/KakaoLogoutController.java
@@ -1,4 +1,4 @@
-package com.momo.config.controller;
+package com.momo.auth.controller;
 
 import com.momo.config.JWTUtil;
 import com.momo.config.token.repository.RefreshTokenRepository;
@@ -21,13 +21,13 @@ import org.springframework.web.client.RestTemplate;
 @RestController
 @RequestMapping
 @Slf4j
-public class LogoutController {
+public class KakaoLogoutController {
 
   private final RefreshTokenRepository refreshTokenRepository;
   private final JWTUtil jwtUtil;
   private final RestTemplate restTemplate;
 
-  public LogoutController(JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository, RestTemplate restTemplate) {
+  public KakaoLogoutController(JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository, RestTemplate restTemplate) {
     this.jwtUtil = jwtUtil;
     this.refreshTokenRepository = refreshTokenRepository;
     this.restTemplate = restTemplate;


### PR DESCRIPTION
## 📌 관련 이슈
- Relates to: #41 

## 📝 변경 사항
### AS-IS
- 카카오 계정 연동 해제 기능의 부재


### TO-BE
- 일반 회원의 로그아웃은 LogoutFilter로 작동하고있고 kakao logout은 기존LogoutContoller에서 진행되기때문에 파일 구분이 어려움. 
- "Kakao"LogdoutContoller로 Rename, Kakao 관련 패키지 하위로 이동하여 정확한 구별

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 카카오 연동 해제 API 테스트
<img width="747" alt="카카오 연동 해제" src="https://github.com/user-attachments/assets/958b72a8-1f51-4462-b62f-8023db80027f" />


## ✅ 체크리스트
- [ ] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 각자 로컬에서 연동해제 후 로그인 시도시 오류를 반환하고 처음 이메일 동의부터 필요로 하고있는지 확인해주세요.
(이렇게되어야 맞습니다!) 
- 제가 알아본 한해서는 카카오에서는 연동 해제 API를 제공하고있기때문에 연동해제로 구현했습니다. 
일반 회원 탈퇴시 DB에서도 정보가 삭제되지만 , 카카오 회원 연동해제 후에도 DB는 잔재하고있습니다. 
카카오 연동해제 회원의 DB까지 삭제되도록 하는 구현이 조금 까다로워 구현이 가능하다 장담 못할 것 같습니다.