### PR TITLE
[feature] 카카오 연동해제 회원 정보 DB 삭제

### DIFF
--- a/src/main/java/com/momo/auth/controller/KakaoDeleteController.java
+++ b/src/main/java/com/momo/auth/controller/KakaoDeleteController.java
@@ -1,7 +1,14 @@
 package com.momo.auth.controller;
 
+import com.momo.auth.dto.KakaoProfile;
+import com.momo.auth.service.KakaoAuthService;
 import com.momo.config.JWTUtil;
 import com.momo.config.token.repository.RefreshTokenRepository;
+import com.momo.user.entity.User;
+import com.momo.user.repository.UserRepository;
+import com.momo.user.service.UserService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -21,17 +28,14 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 @RestController
 @RequestMapping
+@RequiredArgsConstructor
 public class KakaoDeleteController {
 
   private final RefreshTokenRepository refreshTokenRepository;
   private final JWTUtil jwtUtil;
   private final RestTemplate restTemplate;
-
-  public KakaoDeleteController(JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository, RestTemplate restTemplate) {
-    this.jwtUtil = jwtUtil;
-    this.refreshTokenRepository = refreshTokenRepository;
-    this.restTemplate = restTemplate;
-  }
+  private final UserRepository userRepository;
+  private final KakaoAuthService kakaoAuthService;
 
   @DeleteMapping("/api/v1/kakao/delete")
   @Transactional
@@ -39,25 +43,44 @@ public class KakaoDeleteController {
     // Authorization 헤더에서 Bearer 토큰 추출
     String accessToken = extractAccessTokenFromAuthorizationHeader(request);
 
-    // 엑세스 토큰이 없으면 에러 반환
     if (accessToken == null) {
       return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Access token is missing");
     }
 
     try {
-      // 카카오 회원 탈퇴 처리
+      // 카카오 프로필 가져오기
+      KakaoProfile kakaoProfile = kakaoAuthService.getKakaoProfile(accessToken);
+      String email = kakaoProfile.getKakao_account().getEmail();
+
+      if (email == null) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Failed to retrieve Kakao user email");
+      }
+
+      // 카카오 회원 탈퇴 API 호출
       deleteKakaoUser(accessToken);
 
-      // 카카오 회원 탈퇴 후 쿠키 삭제 및 DB에서 Refresh Token 삭제
-      clearRefreshCookie(response);
-      String email = "kakao_user_email";  // 카카오 이메일을 어떻게 가져올지에 대한 추가 로직 필요
-      refreshTokenRepository.deleteByEmail(email);
+      // DB에서 사용자 삭제
+      Optional<User> userOptional = userRepository.findByEmail(email);
+      if (userOptional.isPresent()) {
+        User user = userOptional.get();
 
-      return ResponseEntity.ok("카카오 계정 연동이 해제되었습니다.");
+        // RefreshToken 삭제
+        refreshTokenRepository.deleteByUser(user);
+
+        // User 삭제
+        userRepository.delete(user);
+      }
+
+      // 쿠키 삭제
+      clearRefreshCookie(response);
+
+      return ResponseEntity.ok("카카오 연동 회원 탈퇴가 완료되었습니다.");
     } catch (Exception e) {
+      log.error("Error occurred while unlinking Kakao account: ", e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("인증에 실패했습니다.");
     }
   }
+
 
   private void deleteKakaoUser(String accessToken) {
     String kakaoDeleteUrl = "https://kapi.kakao.com/v1/user/unlink";


### PR DESCRIPTION
## 📌 관련 이슈
- Relates to: #49 

## 📝 변경 사항
### AS-IS
- 카카오 로그인 회원의 연동이 해제되어도 회원정보가 DB 에는 잔재 
- 회의 결과 회원탈퇴시 회원정보를 비롯한 채팅방 정보까지 삭제되어야 한다는 의견으로 해당 기능을 추가 구현


### TO-BE
- 회의 결과 회원탈퇴시 회원정보를 비롯한 채팅방 정보까지 삭제되어야 한다는 의견으로 해당 기능을 추가 구현
- KakaoDeleteController에  연동해제 회원의 DB 정보 삭제하는 로직을 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷

- 카카오 로그인 회원의 연동해제 전 DB 
<img width="1119" alt="카카오 회원 탈퇴 전 DB" src="https://github.com/user-attachments/assets/a10db722-55f2-40e1-8d8c-02ac53b32287" />

- 카카오 회원 연동해제 / 탈퇴 요청
<img width="740" alt="카카오 회원 탈퇴 요청" src="https://github.com/user-attachments/assets/7fe2947f-5854-4507-90d1-ed55f08e0343" />

- 연동해제된 회원의 정보 DB 삭제
<img width="829" alt="카카오 회원 탈퇴 후 DB 정보 삭제" src="https://github.com/user-attachments/assets/dd5b1cef-1190-4f13-852a-866dcb645e33" />



## ✅ 체크리스트
- [ ] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게

- KakaoDeleteController 내부 try-catch문이 코드의 간결화를 방해하고 있지만 추후에 수정해볼 수 있도록 하겠습니다.
- 리뷰 부탁드립니다.