### PR TITLE
[Feature] 채팅 메시지 목록 조회 기능 및 기타수정

### DIFF
--- a/src/main/java/com/momo/chat/controller/ChatController.java
+++ b/src/main/java/com/momo/chat/controller/ChatController.java
@@ -4,7 +4,6 @@ import com.momo.chat.dto.ChatRequestDto;
 import com.momo.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/momo/chat/controller/ChatController.java
+++ b/src/main/java/com/momo/chat/controller/ChatController.java
@@ -17,16 +17,19 @@ public class ChatController {
   // 메시지 발송 (사용자가 채팅방에 메시지를 보내는 경우)
   @MessageMapping("/chat/message")
   public void sendMessage(ChatRequestDto dto) {
-    System.out.println("받은 메시지: " + dto.getMessage());
-    System.out.println("채팅방 ID: " + dto.getRoomId());
     chatService.sendMessage(dto.getUserId(), dto);
   }
 
-  // 채팅방에 입장하면 구독 처리 (여기서는 단순히 방에 메시지를 발송)
+  // 채팅방에 입장하면 방에 메시지를 발송
   @MessageMapping("/enterRoom")
   public void enterRoom(ChatRequestDto dto) {
-    // 채팅방에 입장할 때, 채팅방에 인사 메시지를 전송
     chatService.enterRoom(dto.getUserId(), dto);
+  }
+
+  // 채팅방에 퇴장하면 방에 메시지를 발송
+  @MessageMapping("/leaveRoom")
+  public void leaveRoom(ChatRequestDto dto) {
+    chatService.leaveRoom(dto.getUserId(), dto);
   }
 
 

--- a/src/main/java/com/momo/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/momo/chat/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.momo.chat.controller;
 
+import com.momo.chat.dto.ChatHistoryResponseDto;
 import com.momo.chat.dto.ChatRoomResponseDto;
 import com.momo.chat.service.ChatRoomService;
 import com.momo.user.dto.CustomUserDetails;
@@ -33,35 +34,35 @@ public class ChatRoomController {
   }
 
   // 채팅방 입장
-  @PostMapping("/join/{chatRoomId}")
+  @PostMapping("/{roomId}/join")
   public ResponseEntity<ChatRoomResponseDto> joinRoom(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @PathVariable Long chatRoomId
+      @PathVariable Long roomId
   ) {
     ChatRoomResponseDto roomData = chatRoomService.joinRoom(
-        customUserDetails.getUser().getId(), chatRoomId);
+        customUserDetails.getUser().getId(), roomId);
     return ResponseEntity.ok().body(roomData);
   }
 
   // 채팅방 퇴장
-  @PostMapping("/leave/{chatRoomId}")
+  @PostMapping("/{roomId}/leave")
   public ResponseEntity<ChatRoomResponseDto> leaveRoom(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @PathVariable Long chatRoomId
+      @PathVariable Long roomId
   ) {
     ChatRoomResponseDto roomData = chatRoomService.leaveRoom(
-        customUserDetails.getUser().getId(), chatRoomId);
+        customUserDetails.getUser().getId(), roomId);
     return ResponseEntity.ok().body(roomData);
   }
 
   // 참여중인 채팅방 정보 조회
-  @GetMapping("/{chatRoomId}")
+  @GetMapping("/{roomId}")
   public ResponseEntity<ChatRoomResponseDto> getRoom(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @PathVariable Long chatRoomId
+      @PathVariable Long roomId
   ) {
     ChatRoomResponseDto roomData = chatRoomService.getRoom(
-        customUserDetails.getUser().getId(), chatRoomId);
+        customUserDetails.getUser().getId(), roomId);
     return ResponseEntity.ok().body(roomData);
   }
 
@@ -76,35 +77,45 @@ public class ChatRoomController {
   }
 
   // 참여중인 채팅방 참여자 목록 조회
-  @GetMapping("/{chatRoomId}/participants")
+  @GetMapping("/{roomId}/participants")
   public ResponseEntity<List<Long>> getRoomReaders(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @PathVariable Long chatRoomId
+      @PathVariable Long roomId
   ) {
     List<Long> participants = chatRoomService.getRoomReaders(
-        customUserDetails.getUser().getId(), chatRoomId);
+        customUserDetails.getUser().getId(), roomId);
     return ResponseEntity.ok().body(participants);
   }
 
   // 채팅방 삭제 (호스트만 가능)
-  @DeleteMapping("/{chatRoomId}")
+  @DeleteMapping("/{roomId}")
   public ResponseEntity<Void> deleteRoom(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @PathVariable Long chatRoomId
+      @PathVariable Long roomId
   ) {
-    chatRoomService.deleteRoom(customUserDetails.getUser().getId(), chatRoomId);
+    chatRoomService.deleteRoom(customUserDetails.getUser().getId(), roomId);
     return ResponseEntity.noContent().build();
   }
 
   // 특정 사용자 강퇴 (호스트만 가능)
-  @PostMapping("/{chatRoomId}/withdrawal/{userId}")
+  @PostMapping("/{roomId}/withdrawal/{userId}")
   public ResponseEntity<ChatRoomResponseDto> withdrawal(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @PathVariable Long chatRoomId,
+      @PathVariable Long roomId,
       @PathVariable Long userId
   ) {
     ChatRoomResponseDto roomData = chatRoomService.withdrawal(
-        customUserDetails.getUser().getId(), chatRoomId, userId);
+        customUserDetails.getUser().getId(), roomId, userId);
     return ResponseEntity.ok().body(roomData);
+  }
+
+  // 채팅 기록 조회
+  @GetMapping("/{roomId}/messages")
+  public ResponseEntity<List<ChatHistoryResponseDto>> getChatHistory(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PathVariable Long roomId) {
+    List<ChatHistoryResponseDto> history = chatRoomService.getChatHistory(
+        customUserDetails.getUser().getId(), roomId);
+    return ResponseEntity.ok(history);
   }
 }

--- a/src/main/java/com/momo/chat/dto/ChatHistoryResponseDto.java
+++ b/src/main/java/com/momo/chat/dto/ChatHistoryResponseDto.java
@@ -1,0 +1,26 @@
+package com.momo.chat.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatHistoryResponseDto {
+  private Long userId;
+  private String userNickname;
+  private String userProfileImageUrl;
+  private String message;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public ChatHistoryResponseDto(Long userId, String userNickname, String userProfileImageUrl,
+      String message, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    this.userId = userId;
+    this.userNickname = userNickname;
+    this.userProfileImageUrl = userProfileImageUrl;
+    this.message = message;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+}

--- a/src/main/java/com/momo/chat/entity/ChatRoom.java
+++ b/src/main/java/com/momo/chat/entity/ChatRoom.java
@@ -55,9 +55,5 @@ public class ChatRoom extends BaseEntity {
   @OneToMany(mappedBy = "chatRoom", orphanRemoval = true)
   private List<Chat> ChatMessages = new ArrayList<>();
 
-//  public void update(ChatRoomRequestDto requestDto){
-//    this.title = requestDto.getTitle();
-//    this.content = requestDto.getContent();
-//  }
 
 }

--- a/src/main/java/com/momo/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/momo/chat/exception/ChatErrorCode.java
@@ -1,0 +1,17 @@
+package com.momo.chat.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatErrorCode {
+
+  CHAT_ROOM_NOT_FOUND("해당 채팅방이 없습니다.", HttpStatus.NOT_FOUND),
+  NOT_A_PARTICIPANT("해당 채팅방에 참여 중이 아닙니다.", HttpStatus.FORBIDDEN),
+  ONLY_HOST_CAN_OPERATE("호스트만 이 작업을 수행할 수 있습니다.", HttpStatus.UNAUTHORIZED);
+
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/momo/chat/exception/ChatErrorResponse.java
+++ b/src/main/java/com/momo/chat/exception/ChatErrorResponse.java
@@ -1,0 +1,11 @@
+package com.momo.chat.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatErrorResponse {
+
+  private final String message;
+}

--- a/src/main/java/com/momo/chat/exception/ChatException.java
+++ b/src/main/java/com/momo/chat/exception/ChatException.java
@@ -1,0 +1,14 @@
+package com.momo.chat.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ChatException extends RuntimeException {
+
+  private final ChatErrorCode chatErrorCode;
+
+  public ChatException(ChatErrorCode chatErrorCode) {
+    super(chatErrorCode.getMessage());
+    this.chatErrorCode = chatErrorCode;
+  }
+}

--- a/src/main/java/com/momo/chat/exception/ChatExceptionHandler.java
+++ b/src/main/java/com/momo/chat/exception/ChatExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.momo.chat.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE) // 높은 우선순위로 설정
+@RestControllerAdvice(basePackages = "com.momo.chat")
+public class ChatExceptionHandler {
+
+  @ExceptionHandler(ChatException.class)
+  public ResponseEntity<ChatErrorResponse> handleChatException(ChatException e) {
+    log.error("Chat Exception: {}", e.getMessage());
+    return ResponseEntity
+        .status(e.getChatErrorCode().getStatus())
+        .body(new ChatErrorResponse(e.getChatErrorCode().getMessage()));
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ChatErrorResponse> handleGenericException(Exception e) {
+    log.error("Unexpected error: {}", e.getMessage());
+    return ResponseEntity
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(new ChatErrorResponse("서버 내부 오류가 발생했습니다."));
+  }
+}

--- a/src/main/java/com/momo/chat/repository/ChatRepository.java
+++ b/src/main/java/com/momo/chat/repository/ChatRepository.java
@@ -1,10 +1,13 @@
 package com.momo.chat.repository;
 
 import com.momo.chat.entity.Chat;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+  List<Chat> findAllByChatRoomId(Long chatRoomId);
 
 }

--- a/src/main/java/com/momo/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/momo/chat/repository/ChatRoomRepository.java
@@ -12,9 +12,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
   Optional<ChatRoom> findById(Long roomId);
 
-  Optional<ChatRoom> findByMeetingId(Long meetingId);
-
   List<ChatRoom> findAllByReaderContains(User user);
 
-  Boolean existsByReaderContains(User user);
 }

--- a/src/main/java/com/momo/chat/service/ChatRoomService.java
+++ b/src/main/java/com/momo/chat/service/ChatRoomService.java
@@ -4,11 +4,19 @@ import com.momo.chat.dto.ChatHistoryResponseDto;
 import com.momo.chat.dto.ChatRoomResponseDto;
 import com.momo.chat.entity.Chat;
 import com.momo.chat.entity.ChatRoom;
+import com.momo.chat.exception.ChatErrorCode;
+import com.momo.chat.exception.ChatException;
 import com.momo.chat.repository.ChatRepository;
 import com.momo.chat.repository.ChatRoomRepository;
+import com.momo.common.exception.CustomException;
+import com.momo.common.exception.ErrorCode;
 import com.momo.meeting.entity.Meeting;
+import com.momo.meeting.exception.MeetingErrorCode;
+import com.momo.meeting.exception.MeetingException;
 import com.momo.meeting.repository.MeetingRepository;
 import com.momo.profile.entity.Profile;
+import com.momo.profile.exception.ProfileErrorCode;
+import com.momo.profile.exception.ProfileException;
 import com.momo.profile.repository.ProfileRepository;
 import com.momo.user.entity.User;
 import com.momo.user.repository.UserRepository;
@@ -31,9 +39,9 @@ public class ChatRoomService {
   // 채팅방 생성
   public ChatRoomResponseDto createChatRoom(Long userId, Long meetingId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     Meeting meeting = meetingRepository.findById(meetingId)
-        .orElseThrow(() -> new RuntimeException("해당 모임이 없습니다."));
+        .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
 
     List<User> readers = new ArrayList<>();
     readers.add(user);
@@ -53,9 +61,9 @@ public class ChatRoomService {
   // 채팅방 입장
   public ChatRoomResponseDto joinRoom(Long userId, Long chatRoomId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new RuntimeException("해당 채팅방이 없습니다."));
+        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
     List<User> readers = chatRoom.getReader();
     readers.add(user);
@@ -67,9 +75,9 @@ public class ChatRoomService {
   // 채팅방 퇴장
   public ChatRoomResponseDto leaveRoom(Long userId, Long chatRoomId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new RuntimeException("해당 채팅방이 없습니다."));
+        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
     List<User> readers = chatRoom.getReader();
     readers.remove(user);
@@ -81,11 +89,11 @@ public class ChatRoomService {
   // 참여중인 채팅방 정보 조회
   public ChatRoomResponseDto getRoom(Long userId, Long chatRoomId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new RuntimeException("해당 채팅방이 없습니다."));
+        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
     if (!chatRoom.getReader().contains(user)) {
-      throw new RuntimeException("해당 채팅방에 참여 중이 아닙니다.");
+      throw new ChatException(ChatErrorCode.NOT_A_PARTICIPANT);
     }
 
     return ChatRoomResponseDto.of(chatRoom);
@@ -94,7 +102,7 @@ public class ChatRoomService {
   // 로그인한 유저의 모든 채팅방 목록 조회
   public List<ChatRoomResponseDto> getRooms(Long userId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
     List<ChatRoom> ChatRooms = chatRoomRepository.findAllByReaderContains(user);
 
@@ -106,12 +114,12 @@ public class ChatRoomService {
   // 참여중인 채팅방 참여자 목록 조회
   public List<Long> getRoomReaders(Long userId, Long chatRoomId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new RuntimeException("해당 채팅방이 없습니다."));
+        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
     if (!chatRoom.getReader().contains(user)) {
-      throw new RuntimeException("해당 채팅방에 참여 중이 아닙니다.");
+      throw new ChatException(ChatErrorCode.NOT_A_PARTICIPANT);
     }
 
     return chatRoom.getReader().stream()
@@ -122,12 +130,12 @@ public class ChatRoomService {
   // 채팅방 삭제 (호스트만 가능)
   public void deleteRoom(Long userId, Long chatRoomId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new RuntimeException("해당 채팅방이 없습니다."));
+        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
     if (!chatRoom.getHost().getId().equals(user.getId())) {
-      throw new RuntimeException("호스트만 채팅방을 삭제할 수 있습니다.");
+      throw new ChatException(ChatErrorCode.ONLY_HOST_CAN_OPERATE);
     }
 
     chatRoomRepository.delete(chatRoom);
@@ -136,20 +144,20 @@ public class ChatRoomService {
   // 특정 사용자 강퇴 (호스트만 가능)
   public ChatRoomResponseDto withdrawal(Long hostUserId, Long chatRoomId, Long targetUserId) {
     User hostUser = userRepository.findById(hostUserId)
-        .orElseThrow(() -> new RuntimeException("호스트 회원을 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     User targetUser = userRepository.findById(targetUserId)
-        .orElseThrow(() -> new RuntimeException("강제 퇴장할 사용자를 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new RuntimeException("해당 채팅방이 없습니다."));
+        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
     // 호스트만 강제 퇴장을 시킬 수 있음
     if (!chatRoom.getHost().getId().equals(hostUser.getId())) {
-      throw new RuntimeException("호스트만 사용자를 강제 퇴장시킬 수 있습니다.");
+      throw new ChatException(ChatErrorCode.ONLY_HOST_CAN_OPERATE);
     }
 
     // 강제 퇴장 대상 사용자가 채팅방에 참여 중인지 확인
     if (!chatRoom.getReader().contains(targetUser)) {
-      throw new RuntimeException("해당 사용자는 채팅방에 참여 중이 아닙니다.");
+      throw new ChatException(ChatErrorCode.NOT_A_PARTICIPANT);
     }
 
     // 채팅방에서 퇴장 대상 사용자 제거
@@ -162,14 +170,14 @@ public class ChatRoomService {
   // 채팅 기록 조회
   public List<ChatHistoryResponseDto> getChatHistory(Long userId, Long chatRoomId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new RuntimeException("해당 채팅방이 없습니다."));
+        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
     Profile profile = profileRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("프로필을 찾을 수 없습니다."));
+        .orElseThrow(() -> new ProfileException(ProfileErrorCode.INVALID_IMAGE_FORMAT));
 
     if (!chatRoom.getReader().contains(user)) {
-      throw new RuntimeException("해당 채팅방에 참여 중이 아닙니다.");
+      throw new ChatException(ChatErrorCode.NOT_A_PARTICIPANT);
     }
 
     List<Chat> chats = chatRepository.findAllByChatRoomId(chatRoomId);// 채팅방 ID로 모든 채팅 조회

--- a/src/main/java/com/momo/chat/service/ChatRoomService.java
+++ b/src/main/java/com/momo/chat/service/ChatRoomService.java
@@ -4,22 +4,12 @@ import com.momo.chat.dto.ChatHistoryResponseDto;
 import com.momo.chat.dto.ChatRoomResponseDto;
 import com.momo.chat.entity.Chat;
 import com.momo.chat.entity.ChatRoom;
-import com.momo.chat.exception.ChatErrorCode;
-import com.momo.chat.exception.ChatException;
 import com.momo.chat.repository.ChatRepository;
 import com.momo.chat.repository.ChatRoomRepository;
-import com.momo.common.exception.CustomException;
-import com.momo.common.exception.ErrorCode;
+import com.momo.chat.validator.ChatValidator;
 import com.momo.meeting.entity.Meeting;
-import com.momo.meeting.exception.MeetingErrorCode;
-import com.momo.meeting.exception.MeetingException;
-import com.momo.meeting.repository.MeetingRepository;
 import com.momo.profile.entity.Profile;
-import com.momo.profile.exception.ProfileErrorCode;
-import com.momo.profile.exception.ProfileException;
-import com.momo.profile.repository.ProfileRepository;
 import com.momo.user.entity.User;
-import com.momo.user.repository.UserRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,16 +22,12 @@ public class ChatRoomService {
 
   private final ChatRepository chatRepository;
   private final ChatRoomRepository chatRoomRepository;
-  private final MeetingRepository meetingRepository;
-  private final UserRepository userRepository;
-  private final ProfileRepository profileRepository;
+  private final ChatValidator chatValidator;
 
   // 채팅방 생성
   public ChatRoomResponseDto createChatRoom(Long userId, Long meetingId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    Meeting meeting = meetingRepository.findById(meetingId)
-        .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
+    User user = chatValidator.validateUserExists(userId);
+    Meeting meeting = chatValidator.validateMeetingExists(meetingId);
 
     List<User> readers = new ArrayList<>();
     readers.add(user);
@@ -60,10 +46,8 @@ public class ChatRoomService {
 
   // 채팅방 입장
   public ChatRoomResponseDto joinRoom(Long userId, Long chatRoomId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    ChatRoom chatRoom = chatValidator.validateChatRoomExists(chatRoomId);
+    User user = chatValidator.validateUserExists(userId);
 
     List<User> readers = chatRoom.getReader();
     readers.add(user);
@@ -74,10 +58,8 @@ public class ChatRoomService {
 
   // 채팅방 퇴장
   public ChatRoomResponseDto leaveRoom(Long userId, Long chatRoomId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    ChatRoom chatRoom = chatValidator.validateChatRoomExists(chatRoomId);
+    User user = chatValidator.validateUserExists(userId);
 
     List<User> readers = chatRoom.getReader();
     readers.remove(user);
@@ -88,21 +70,14 @@ public class ChatRoomService {
 
   // 참여중인 채팅방 정보 조회
   public ChatRoomResponseDto getRoom(Long userId, Long chatRoomId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
-    if (!chatRoom.getReader().contains(user)) {
-      throw new ChatException(ChatErrorCode.NOT_A_PARTICIPANT);
-    }
+    ChatRoom chatRoom = chatValidator.validateUserParticipation(userId, chatRoomId);
 
     return ChatRoomResponseDto.of(chatRoom);
   }
 
   // 로그인한 유저의 모든 채팅방 목록 조회
   public List<ChatRoomResponseDto> getRooms(Long userId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    User user = chatValidator.validateUserExists(userId);
 
     List<ChatRoom> ChatRooms = chatRoomRepository.findAllByReaderContains(user);
 
@@ -113,14 +88,7 @@ public class ChatRoomService {
 
   // 참여중인 채팅방 참여자 목록 조회
   public List<Long> getRoomReaders(Long userId, Long chatRoomId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
-
-    if (!chatRoom.getReader().contains(user)) {
-      throw new ChatException(ChatErrorCode.NOT_A_PARTICIPANT);
-    }
+    ChatRoom chatRoom = chatValidator.validateUserParticipation(userId, chatRoomId);
 
     return chatRoom.getReader().stream()
         .map(User::getId)
@@ -129,36 +97,19 @@ public class ChatRoomService {
 
   // 채팅방 삭제 (호스트만 가능)
   public void deleteRoom(Long userId, Long chatRoomId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
-
-    if (!chatRoom.getHost().getId().equals(user.getId())) {
-      throw new ChatException(ChatErrorCode.ONLY_HOST_CAN_OPERATE);
-    }
+    chatValidator.validateHostOperation(userId, chatRoomId);
+    ChatRoom chatRoom = chatValidator.validateChatRoomExists(chatRoomId);
 
     chatRoomRepository.delete(chatRoom);
   }
 
   // 특정 사용자 강퇴 (호스트만 가능)
   public ChatRoomResponseDto withdrawal(Long hostUserId, Long chatRoomId, Long targetUserId) {
-    User hostUser = userRepository.findById(hostUserId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    User targetUser = userRepository.findById(targetUserId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    chatValidator.validateHostOperation(hostUserId, chatRoomId);
+    User targetUser = chatValidator.validateUserExists(targetUserId);
+    ChatRoom chatRoom = chatValidator.validateChatRoomExists(chatRoomId);
 
-    // 호스트만 강제 퇴장을 시킬 수 있음
-    if (!chatRoom.getHost().getId().equals(hostUser.getId())) {
-      throw new ChatException(ChatErrorCode.ONLY_HOST_CAN_OPERATE);
-    }
-
-    // 강제 퇴장 대상 사용자가 채팅방에 참여 중인지 확인
-    if (!chatRoom.getReader().contains(targetUser)) {
-      throw new ChatException(ChatErrorCode.NOT_A_PARTICIPANT);
-    }
+    chatValidator.validateHostOperation(hostUserId, chatRoomId);
 
     // 채팅방에서 퇴장 대상 사용자 제거
     chatRoom.getReader().remove(targetUser);
@@ -169,16 +120,8 @@ public class ChatRoomService {
 
   // 채팅 기록 조회
   public List<ChatHistoryResponseDto> getChatHistory(Long userId, Long chatRoomId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
-    Profile profile = profileRepository.findById(userId)
-        .orElseThrow(() -> new ProfileException(ProfileErrorCode.INVALID_IMAGE_FORMAT));
-
-    if (!chatRoom.getReader().contains(user)) {
-      throw new ChatException(ChatErrorCode.NOT_A_PARTICIPANT);
-    }
+    ChatRoom chatRoom = chatValidator.validateUserParticipation(userId, chatRoomId);
+    Profile profile = chatValidator.validateProfileExists(userId);
 
     List<Chat> chats = chatRepository.findAllByChatRoomId(chatRoomId);// 채팅방 ID로 모든 채팅 조회
 

--- a/src/main/java/com/momo/chat/service/ChatRoomService.java
+++ b/src/main/java/com/momo/chat/service/ChatRoomService.java
@@ -46,8 +46,8 @@ public class ChatRoomService {
 
   // 채팅방 입장
   public ChatRoomResponseDto joinRoom(Long userId, Long chatRoomId) {
-    ChatRoom chatRoom = chatValidator.validateChatRoomExists(chatRoomId);
     User user = chatValidator.validateUserExists(userId);
+    ChatRoom chatRoom = chatValidator.validateChatRoomExists(chatRoomId);
 
     List<User> readers = chatRoom.getReader();
     readers.add(user);
@@ -58,8 +58,8 @@ public class ChatRoomService {
 
   // 채팅방 퇴장
   public ChatRoomResponseDto leaveRoom(Long userId, Long chatRoomId) {
-    ChatRoom chatRoom = chatValidator.validateChatRoomExists(chatRoomId);
     User user = chatValidator.validateUserExists(userId);
+    ChatRoom chatRoom = chatValidator.validateChatRoomExists(chatRoomId);
 
     List<User> readers = chatRoom.getReader();
     readers.remove(user);

--- a/src/main/java/com/momo/chat/service/ChatService.java
+++ b/src/main/java/com/momo/chat/service/ChatService.java
@@ -5,9 +5,8 @@ import com.momo.chat.dto.ChatResponseDto;
 import com.momo.chat.entity.Chat;
 import com.momo.chat.entity.ChatRoom;
 import com.momo.chat.repository.ChatRepository;
-import com.momo.chat.repository.ChatRoomRepository;
+import com.momo.chat.validator.ChatValidator;
 import com.momo.user.entity.User;
-import com.momo.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
@@ -18,16 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatService {
 
   private final SimpMessageSendingOperations messagingTemplate;
-  private final UserRepository userRepository;
   private final ChatRepository chatRepository;
-  private final ChatRoomRepository chatRoomRepository;
+  private final ChatValidator chatValidator;
 
   @Transactional
   public void sendMessage(Long userId, ChatRequestDto dto) {
-    ChatRoom chatRoom = chatRoomRepository.findById(dto.getRoomId())
-        .orElseThrow(() -> new RuntimeException("해당 모임이 없습니다."));
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("User not found"));
+    ChatRoom chatRoom = chatValidator.validateChatRoomExists(dto.getRoomId());
+    User user = chatValidator.validateUserExists(userId);
 
     Chat chat = Chat.builder()
         .sender(user)
@@ -47,16 +43,14 @@ public class ChatService {
 
   @Transactional
   public void enterRoom(Long userId, ChatRequestDto dto) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("User not found"));
+    User user = chatValidator.validateUserExists(userId);
     messagingTemplate.convertAndSend("/sub/chat/room/" + dto.getRoomId(),
         user.getNickname() + "님이 입장했습니다.");
   }
 
   @Transactional
   public void leaveRoom(Long userId, ChatRequestDto dto) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("User not found"));
+    User user = chatValidator.validateUserExists(userId);
     messagingTemplate.convertAndSend("/sub/chat/room/" + dto.getRoomId(),
         user.getNickname() + "님이 퇴장했습니다.");
   }

--- a/src/main/java/com/momo/chat/service/ChatService.java
+++ b/src/main/java/com/momo/chat/service/ChatService.java
@@ -53,5 +53,13 @@ public class ChatService {
         user.getNickname() + "님이 입장했습니다.");
   }
 
+  @Transactional
+  public void leaveRoom(Long userId, ChatRequestDto dto) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new RuntimeException("User not found"));
+    messagingTemplate.convertAndSend("/sub/chat/room/" + dto.getRoomId(),
+        user.getNickname() + "님이 퇴장했습니다.");
+  }
+
 
 }

--- a/src/main/java/com/momo/chat/service/ChatService.java
+++ b/src/main/java/com/momo/chat/service/ChatService.java
@@ -54,6 +54,4 @@ public class ChatService {
   }
 
 
-
-
 }

--- a/src/main/java/com/momo/chat/validator/ChatValidator.java
+++ b/src/main/java/com/momo/chat/validator/ChatValidator.java
@@ -1,0 +1,67 @@
+package com.momo.chat.validator;
+
+import com.momo.chat.entity.ChatRoom;
+import com.momo.chat.exception.ChatErrorCode;
+import com.momo.chat.exception.ChatException;
+import com.momo.chat.repository.ChatRoomRepository;
+import com.momo.common.exception.CustomException;
+import com.momo.common.exception.ErrorCode;
+import com.momo.meeting.entity.Meeting;
+import com.momo.meeting.exception.MeetingErrorCode;
+import com.momo.meeting.exception.MeetingException;
+import com.momo.meeting.repository.MeetingRepository;
+import com.momo.profile.entity.Profile;
+import com.momo.profile.repository.ProfileRepository;
+import com.momo.user.entity.User;
+import com.momo.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatValidator {
+
+  private final ChatRoomRepository chatRoomRepository;
+  private final UserRepository userRepository;
+  private final MeetingRepository meetingRepository;
+  private final ProfileRepository profileRepository;
+
+  public ChatRoom validateUserParticipation(Long userId, Long chatRoomId) {
+    ChatRoom chatRoom = validateChatRoomExists(chatRoomId);
+    User user = validateUserExists(userId);
+
+    if (!chatRoom.getReader().contains(user)) {
+      throw new ChatException(ChatErrorCode.NOT_A_PARTICIPANT);
+    }
+    return chatRoom;
+  }
+
+  public void validateHostOperation(Long userId, Long chatRoomId) {
+    ChatRoom chatRoom = validateChatRoomExists(chatRoomId);
+    User user = validateUserExists(userId);
+
+    if (!chatRoom.getHost().getId().equals(user.getId())) {
+      throw new ChatException(ChatErrorCode.ONLY_HOST_CAN_OPERATE);
+    }
+  }
+
+  public ChatRoom validateChatRoomExists(Long chatRoomId) {
+    return chatRoomRepository.findById(chatRoomId)
+        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+  }
+
+  public User validateUserExists(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+  }
+
+  public Profile validateProfileExists(Long userId) {
+    return profileRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXISTS_PROFILE));
+  }
+
+  public Meeting validateMeetingExists(Long meetingId) {
+    return meetingRepository.findById(meetingId)
+        .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #48 

## 📝 변경 사항
### AS-IS
- 채팅 메시지 목록 조회 기능 부재

### TO-BE
- 채팅 메시지 목록 조회 기능 추가
- 채팅방 입장, 퇴장 메시지
- ErrorCode, Exception 추가
- Validator 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
![성공1](https://github.com/user-attachments/assets/5eeea642-b50c-4807-a1f1-78c8cc9c5e62)
![성공2](https://github.com/user-attachments/assets/f1d3d482-b04f-4b16-8603-8c0816ef3c3d)
테스트 창 2개 띄운 후, 한 곳에서 채팅 보내면 다른 곳에서 받고
![h2db](https://github.com/user-attachments/assets/39bc349b-90c4-4227-9699-e5d60f85a208)
메시지는 db에 저장됩니다.

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
Exception, Validator 는 기존 코드 양식에 최대한 맞추었습니다.
erd는 내일 수정할게요.
