### PR TITLE
[feature] 회원정보 조회

### DIFF
--- a/src/main/java/com/momo/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/momo/auth/service/KakaoAuthService.java
@@ -70,9 +70,17 @@ public class KakaoAuthService {
         String.class
     );
 
-    return parseResponse(response.getBody(), KakaoProfile.class, ErrorCode.INVALID_KAKAO_RESPONSE);
+    return parseResponse(response.getBody());
   }
 
+  private KakaoProfile parseResponse(String body) {
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      return objectMapper.readValue(body, KakaoProfile.class);
+    } catch (Exception e) {
+      throw new RuntimeException("카카오 프로필 정보 파싱 실패", e);
+    }
+  }
   /**
    * 공통 JSON 응답 파싱 메서드
    */

--- a/src/main/java/com/momo/common/exception/ErrorCode.java
+++ b/src/main/java/com/momo/common/exception/ErrorCode.java
@@ -10,8 +10,8 @@ public enum ErrorCode {
   INVALID_KAKAO_RESPONSE("잘못된 Kakao API 응답입니다.", 400),
   INVALID_REQUEST("잘못된 요청입니다.", 400),
   INVALID_TOKEN("유효하지 않은 토큰입니다.", 400),
-  EMAIL_SEND_FAILED("메일 발송을 실패했습니다.",400);
-
+  EMAIL_SEND_FAILED("메일 발송을 실패했습니다.",400),
+  PROFILE_NOT_FOUND("프로필을 찾을 수 없습니다.",400);
 
   private final String message;
   private final int status;

--- a/src/main/java/com/momo/config/SecurityConfig.java
+++ b/src/main/java/com/momo/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.momo.config;
 
 import com.momo.auth.security.CustomLogoutFilter;
 import com.momo.auth.security.LoginFilter;
+import com.momo.auth.service.KakaoAuthService;
 import com.momo.config.constants.EndpointConstants;
 import com.momo.config.token.repository.RefreshTokenRepository;
 import com.momo.user.service.CustomUserDetailsService;
@@ -65,8 +66,8 @@ public class SecurityConfig {
   }
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    JWTFilter jwtFilter = new JWTFilter(userRepository, jwtUtil);
+  public SecurityFilterChain filterChain(HttpSecurity http, KakaoAuthService kakaoAuthService) throws Exception {
+    JWTFilter jwtFilter = new JWTFilter(userRepository, jwtUtil,kakaoAuthService);
     LoginFilter loginFilter = new LoginFilter(authenticationManager(), jwtUtil, refreshTokenRepository, userRepository);
     CustomLogoutFilter logoutFilter = new CustomLogoutFilter(jwtUtil, refreshTokenRepository);
 

--- a/src/main/java/com/momo/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/momo/profile/repository/ProfileRepository.java
@@ -1,6 +1,8 @@
 package com.momo.profile.repository;
 
 import com.momo.profile.entity.Profile;
+import com.momo.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
   boolean existsByUser_Id(Long userId);
+  Optional<Profile> findByUser(User user);
 }

--- a/src/main/java/com/momo/user/controller/UserController.java
+++ b/src/main/java/com/momo/user/controller/UserController.java
@@ -61,17 +61,11 @@ public class UserController {
   }
 
   // 마이페이지 회원정보 조회
+  // 회원정보 조회 (일반 로그인 회원 및 카카오 로그인 회원 모두 처리)
   @GetMapping("/me")
   public ResponseEntity<UserInfoResponse> getUserInfo() {
-    UserInfoResponse userInfo = userService.getUserInfo();
-    return ResponseEntity.ok(userInfo);
-  }
-
-  // 카카오 로그인 회원정보 조회
-  @GetMapping("/me/kakao")
-  public ResponseEntity<UserInfoResponse> getKakaoUserInfo() {
     String email = SecurityContextHolder.getContext().getAuthentication().getName();
-    UserInfoResponse userInfo = userService.getUserInfoForKakaoUser(email);
+    UserInfoResponse userInfo = userService.getUserInfoByEmail(email);
     return ResponseEntity.ok(userInfo);
   }
 }

--- a/src/main/java/com/momo/user/controller/UserController.java
+++ b/src/main/java/com/momo/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.momo.user.controller;
 
 import com.momo.user.dto.EmailRequest;
 import com.momo.user.dto.PasswordResetRequest;
+import com.momo.user.dto.UserInfoResponse;
 import com.momo.user.service.EmailService;
 import com.momo.user.service.UserService;
 import lombok.Data;
@@ -9,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,7 +35,7 @@ public class UserController {
     return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
   }
 
-  // 비밀번호 재설정 요청
+  // 비밀번호 재설정 링크 발송
   @PostMapping("/password/change/link-send")
   public ResponseEntity<String> requestPasswordReset(@RequestBody EmailRequest emailRequest) {
     if (emailRequest.getEmail() == null || emailRequest.getEmail().isEmpty()) {
@@ -43,6 +46,7 @@ public class UserController {
     return ResponseEntity.ok("비밀번호 재설정 이메일이 발송되었습니다.");
   }
 
+  // 비밀번호 재설정
   @PostMapping("/password/change")
   public ResponseEntity<String> resetPassword(@RequestBody PasswordResetRequest passwordResetRequest) {
     if (passwordResetRequest.getToken() == null || passwordResetRequest.getToken().isEmpty()) {
@@ -54,5 +58,20 @@ public class UserController {
 
     userService.resetPassword(passwordResetRequest.getToken(), passwordResetRequest.getNewPassword());
     return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+  }
+
+  // 마이페이지 회원정보 조회
+  @GetMapping("/me")
+  public ResponseEntity<UserInfoResponse> getUserInfo() {
+    UserInfoResponse userInfo = userService.getUserInfo();
+    return ResponseEntity.ok(userInfo);
+  }
+
+  // 카카오 로그인 회원정보 조회
+  @GetMapping("/me/kakao")
+  public ResponseEntity<UserInfoResponse> getKakaoUserInfo() {
+    String email = SecurityContextHolder.getContext().getAuthentication().getName();
+    UserInfoResponse userInfo = userService.getUserInfoForKakaoUser(email);
+    return ResponseEntity.ok(userInfo);
   }
 }

--- a/src/main/java/com/momo/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/momo/user/dto/UserInfoResponse.java
@@ -1,0 +1,26 @@
+package com.momo.user.dto;
+
+import com.momo.profile.constant.Gender;
+import com.momo.profile.constant.Mbti;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoResponse {
+  private String nickname;
+  private String phone;
+  private String email;
+  private Gender gender;
+  private LocalDate birth;
+  private String profileImageUrl;
+  private String introduction;
+  private Mbti mbti;
+  private String oauthProvider;
+}

--- a/src/main/java/com/momo/user/entity/User.java
+++ b/src/main/java/com/momo/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.momo.user.entity;
 
 import com.momo.config.token.entity.RefreshToken;
+import com.momo.profile.entity.Profile;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -93,6 +94,9 @@ public class User {
   public List<GrantedAuthority> getAuthorities() {
     return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
   }
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<Profile> profiles = new ArrayList<>();
 
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Relates to: #50 

## 📝 변경 사항
### AS-IS
- 회원은 마이페이지 '내 정보' 카테고리에서 회원정보를 조회할 수 있다.
- 조회항목 :  닉네임, 핸드폰 번호, 이메일, 성별, 생년월일, 프로필 사진, 자기소개, MBTI
- fix 프로필 생성 후 회원탈퇴 기능의 오류 발생

### TO-BE
- 카카오 로그인시 필수로 받아오는 이메일 정보를 추출하기 위해 "https://kapi.kakao.com/v2/user/me" 카카오에서 제공하는 카카오 프로필 요청 API 사용
- User 엔티티에서 Profile 엔티티로의 @OneToMany 관계에 CascadeType.REMOVE를 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 일반회원 / 카카오로그인 회원프로필 생성
<img width="740" alt="일반회원 프로필 생성" src="https://github.com/user-attachments/assets/9c486d26-34b9-4454-b3e3-6814972f5139" />

<img width="740" alt="카카오로그인 회원 프로필 생성" src="https://github.com/user-attachments/assets/d24cf229-07be-4eb6-8cfc-ebd6a6c6597f" />


- 일반회원 / 카카오 로그인회원 프로필 회원 정보 DB 저장 확인
<img width="1112" alt="생성된 프로필 정보 DB 저장" src="https://github.com/user-attachments/assets/92091900-6d25-4267-a0ff-f4d4e41f3ff0" />


- 일반회원 / 카카오 로그인 회원 회원 정보 조회
<img width="740" alt="일반회원 회원정보 조회" src="https://github.com/user-attachments/assets/7ae43436-21cd-4a31-985b-3c43cdd5ab89" />
<img width="740" alt="카카오 로그인 회원 회원정보 조회" src="https://github.com/user-attachments/assets/f85820f8-48b0-4f5b-b8b6-d012ed293008" />

- 회원 탈퇴 오류 해결
<img width="738" alt="일반 로그인 회원 탈퇴" src="https://github.com/user-attachments/assets/e22f853f-150b-43a4-a937-91742841bdfc" />
<img width="738" alt="카카오 회원 탈퇴" src="https://github.com/user-attachments/assets/c9de984c-5bdc-4f49-8186-91e257fc286e" />

- 탈퇴 처리 후 DB 삭제 확인
<img width="738" alt="탈퇴 처리 후 DB 정보 삭제 확인" src="https://github.com/user-attachments/assets/d8481cdb-7df4-48fd-b30e-db7f1e643355" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
엔드포인트를 하나로 병합한 뒤 로직 안에서 일반 로그인과 카카오 로그인을 구별하도록 수정했습니다.