### PR TITLE
[Feature] 모임 목록 조회 시 위치 정보 없다면 "모임 날짜"를 기준으로 정렬 및 각 모집글 정보에 작성자의 userId 포함하여 반환하도록 수정

### DIFF
--- a/src/main/java/com/momo/meeting/controller/MeetingController.java
+++ b/src/main/java/com/momo/meeting/controller/MeetingController.java
@@ -8,10 +8,12 @@ import com.momo.meeting.dto.MeetingsResponse;
 import com.momo.meeting.service.MeetingService;
 import com.momo.user.dto.CustomUserDetails;
 import java.net.URI;
+import java.time.LocalDateTime;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -51,10 +53,12 @@ public class MeetingController {
       @RequestParam(required = false) @Range(min = -180, max = 180) Double longitude,
       @RequestParam(required = false) Long lastId,
       @RequestParam(required = false) Double lastDistance,
+      @RequestParam(required = false)
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastMeetingDateTime,
       @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int pageSize
   ) {
     MeetingsRequest request = MeetingsRequest
-        .createRequest(latitude, longitude, lastId, lastDistance, pageSize);
+        .createRequest(latitude, longitude, lastId, lastDistance, lastMeetingDateTime, pageSize);
     return ResponseEntity.ok(meetingService.getMeetings(request));
   }
 

--- a/src/main/java/com/momo/meeting/dto/MeetingCursor.java
+++ b/src/main/java/com/momo/meeting/dto/MeetingCursor.java
@@ -1,5 +1,6 @@
 package com.momo.meeting.dto;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,13 +8,15 @@ import lombok.Getter;
 @Builder
 public class MeetingCursor {
 
-  private Long id;
-  private Double distance;
+  private final Long id;
+  private final Double distance;
+  private final LocalDateTime meetingDateTime;
 
-  public static MeetingCursor of(Long id, Double distance) {
+  public static MeetingCursor of(Long id, Double distance, LocalDateTime meetingDateTime) {
     return MeetingCursor.builder()
         .id(id)
         .distance(distance)
+        .meetingDateTime(meetingDateTime)
         .build();
   }
 }

--- a/src/main/java/com/momo/meeting/dto/MeetingDto.java
+++ b/src/main/java/com/momo/meeting/dto/MeetingDto.java
@@ -1,16 +1,11 @@
 package com.momo.meeting.dto;
 
 import com.momo.meeting.constant.FoodCategory;
-import com.momo.meeting.exception.MeetingErrorCode;
-import com.momo.meeting.exception.MeetingException;
 import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MeetingDto {
 
   private Long id;
+  private Long authorId;
   private String title;
   private Long locationId;
   private Double latitude;
@@ -51,6 +47,7 @@ public class MeetingDto {
     Set<String> foodCategories = FoodCategory.convertToFoodCategories(meeting.getCategory());
     return MeetingDto.builder()
         .id(meeting.getId())
+        .authorId(meeting.getAuthorId())
         .title(meeting.getTitle())
         .locationId(meeting.getLocationId())
         .latitude(meeting.getLatitude())

--- a/src/main/java/com/momo/meeting/dto/MeetingsRequest.java
+++ b/src/main/java/com/momo/meeting/dto/MeetingsRequest.java
@@ -1,6 +1,7 @@
 package com.momo.meeting.dto;
 
 import com.momo.meeting.constant.SortType;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,8 @@ public class MeetingsRequest {
 
   private static final Long DEFAULT_LAST_ID = 0L;
   private static final double DEFAULT_RADIUS = 3000;
+  private static final LocalDateTime DEFAULT_LAST_DATETIME =
+      LocalDateTime.of(1970, 1, 1, 0, 0);
 
   private Double userLatitude;
   private Double userLongitude;
@@ -23,16 +26,19 @@ public class MeetingsRequest {
       Double userLongitude,
       Long lastId,
       Double lastDistance,
+      LocalDateTime lastMeetingDateTime,
       int pageSize
   ) {
     lastId = lastId == null ? DEFAULT_LAST_ID : lastId;
     lastDistance = lastDistance == null ? Double.MIN_VALUE : lastDistance;
+    lastMeetingDateTime = lastMeetingDateTime == null ?
+        DEFAULT_LAST_DATETIME : lastMeetingDateTime;
 
     return MeetingsRequest.builder()
         .userLatitude(userLatitude)
         .userLongitude(userLongitude)
         .radius(DEFAULT_RADIUS)
-        .meetingCursor(MeetingCursor.of(lastId, lastDistance))
+        .meetingCursor(MeetingCursor.of(lastId, lastDistance, lastMeetingDateTime))
         .pageSize(pageSize)
         .sortType(determineSortType(userLatitude, userLongitude))
         .build();
@@ -44,7 +50,10 @@ public class MeetingsRequest {
 
   public Double getCursorDistance() {
     return meetingCursor.getDistance();
+  }
 
+  public LocalDateTime getCursorMeetingDateTime() {
+    return meetingCursor.getMeetingDateTime();
   }
 
   private static SortType determineSortType(Double latitude, Double longitude) {

--- a/src/main/java/com/momo/meeting/projection/MeetingToMeetingDtoProjection.java
+++ b/src/main/java/com/momo/meeting/projection/MeetingToMeetingDtoProjection.java
@@ -6,6 +6,8 @@ public interface MeetingToMeetingDtoProjection {
 
   Long getId();
 
+  Long getAuthorId();
+
   String getTitle();
 
   Long getLocationId();

--- a/src/main/java/com/momo/meeting/service/MeetingService.java
+++ b/src/main/java/com/momo/meeting/service/MeetingService.java
@@ -38,7 +38,6 @@ public class MeetingService {
   }
 
   public MeetingsResponse getMeetings(MeetingsRequest request) {
-// TODO: 각 모집글 주최자 아이디 같이 반환 필요.
     List<MeetingToMeetingDtoProjection> meetingProjections;
 
     if (request.getSortType() == SortType.DISTANCE) {
@@ -84,8 +83,9 @@ public class MeetingService {
   private List<MeetingToMeetingDtoProjection> getMeetingsByDate(
       MeetingsRequest request
   ) {
-    return meetingRepository.findOrderByCreatedAtWithCursor(
+    return meetingRepository.findOrderByMeetingDateWithCursor(
         request.getCursorId(),
+        request.getCursorMeetingDateTime(),
         request.getPageSize() + 1 // 다음 페이지 존재 여부를 알기 위해 + 1
     );
   }
@@ -96,7 +96,11 @@ public class MeetingService {
     }
     MeetingToMeetingDtoProjection lastProjection = meetingProjections
         .get(meetingProjections.size() - 1);
-    return MeetingCursor.of(lastProjection.getId(), lastProjection.getDistance());
+    return MeetingCursor.of(
+        lastProjection.getId(),
+        lastProjection.getDistance(),
+        lastProjection.getMeetingDateTime()
+    );
   }
 
   private void validateDailyPostLimit(Long userId) {


### PR DESCRIPTION
## 📌 관련 이슈
- close #77 

## 📝 변경 사항
### AS-IS
- 위치 정보 없이 모임 목록 조회 시 create_at을 기준으로 정렬되어 반환됨
- 각 모집글 정보에 작성자의 userId가 없음

### TO-BE
- 위치 정보 없이 모임 목록 조회 시 meeting_date_time을 기준으로 정렬되어 반환하도록 구현
- 각 모집글 정보에 작성자의 userId 포함하여 반환

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
![get-meetingList-orderby-meetingDateTime_1](https://github.com/user-attachments/assets/f6db4590-38f8-44d2-af8f-3c719a356699)
![get-meetingList-orderby-meetingDateTime_2](https://github.com/user-attachments/assets/49b58a3b-b0f3-43c4-95b0-5fd3229183bf)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.