### PR TITLE
[Feature] 개최한 모임 목록 조회

### DIFF
--- a/src/main/java/com/momo/meeting/controller/MeetingController.java
+++ b/src/main/java/com/momo/meeting/controller/MeetingController.java
@@ -1,6 +1,7 @@
 package com.momo.meeting.controller;
 
 import com.momo.meeting.constant.MeetingStatus;
+import com.momo.meeting.dto.CreatedMeetingsResponse;
 import com.momo.meeting.dto.create.MeetingCreateRequest;
 import com.momo.meeting.dto.create.MeetingCreateResponse;
 import com.momo.meeting.dto.MeetingsRequest;
@@ -61,6 +62,25 @@ public class MeetingController {
     MeetingsRequest request = MeetingsRequest
         .createRequest(latitude, longitude, lastId, lastDistance, lastMeetingDateTime, pageSize);
     return ResponseEntity.ok(meetingService.getMeetings(request));
+  }
+
+  /**
+   * 주최한 모집글 목록 조회
+   *
+   * @param customUserDetails 회원 정보
+   * @param lastId            마지막으로 조회된 모임 ID
+   * @param pageSize          조회할 모임 수
+   * @return CreatedMeetingsResponse
+   */
+  @GetMapping("/created")
+  public ResponseEntity<CreatedMeetingsResponse> getCreatedMeetings(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @RequestParam(defaultValue = "0") Long lastId,
+      @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int pageSize
+  ) {
+    CreatedMeetingsResponse response =
+        meetingService.getCreatedMeetings(customUserDetails.getId(), lastId, pageSize);
+    return ResponseEntity.ok(response);
   }
 
   @PutMapping("/{meetingId}")

--- a/src/main/java/com/momo/meeting/controller/MeetingController.java
+++ b/src/main/java/com/momo/meeting/controller/MeetingController.java
@@ -1,7 +1,7 @@
 package com.momo.meeting.controller;
 
 import com.momo.meeting.constant.MeetingStatus;
-import com.momo.meeting.dto.CreatedMeetingsResponse;
+import com.momo.meeting.dto.createdMeeting.CreatedMeetingsResponse;
 import com.momo.meeting.dto.create.MeetingCreateRequest;
 import com.momo.meeting.dto.create.MeetingCreateResponse;
 import com.momo.meeting.dto.MeetingsRequest;

--- a/src/main/java/com/momo/meeting/dto/createdMeeting/CreatedMeetingDto.java
+++ b/src/main/java/com/momo/meeting/dto/createdMeeting/CreatedMeetingDto.java
@@ -1,0 +1,67 @@
+package com.momo.meeting.dto.createdMeeting;
+
+import com.momo.meeting.constant.FoodCategory;
+import com.momo.meeting.constant.MeetingStatus;
+import com.momo.meeting.projection.CreatedMeetingProjection;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreatedMeetingDto {
+
+  private Long id;
+  private Long meetingId;
+  private MeetingStatus meetingStatus;
+  private String title;
+  private Long locationId;
+  private Double latitude;
+  private Double longitude;
+  private String address;
+  private LocalDateTime meetingDateTime;
+  private Integer maxCount;
+  private Integer approvedCount;
+  private Set<String> category;
+  private String content;
+  private String thumbnailUrl;
+
+  public static List<CreatedMeetingDto> convertToCreatedMeetingDto(
+      List<CreatedMeetingProjection> createdMeetingProjections
+  ) {
+    List<CreatedMeetingDto> createdMeetingDtos = new ArrayList<>();
+
+    for (CreatedMeetingProjection createdMeetingProjection : createdMeetingProjections) {
+      CreatedMeetingDto createdMeetingDto = CreatedMeetingDto.from(createdMeetingProjection);
+      createdMeetingDtos.add(createdMeetingDto);
+    }
+    return createdMeetingDtos;
+  }
+
+  public static CreatedMeetingDto from(CreatedMeetingProjection createdMeetingProjection) {
+    Set<String> foodCategories = FoodCategory
+        .convertToFoodCategories(createdMeetingProjection.getCategory());
+
+    return CreatedMeetingDto.builder()
+        .id(createdMeetingProjection.getId())
+        .meetingId(createdMeetingProjection.getMeetingId())
+        .meetingStatus(createdMeetingProjection.getMeetingStatus())
+        .title(createdMeetingProjection.getTitle())
+        .locationId(createdMeetingProjection.getLocationId())
+        .latitude(createdMeetingProjection.getLatitude())
+        .longitude(createdMeetingProjection.getLongitude())
+        .address(createdMeetingProjection.getAddress())
+        .meetingDateTime(
+            createdMeetingProjection.getMeetingDateTime().truncatedTo(ChronoUnit.MINUTES))
+        .maxCount(createdMeetingProjection.getMaxCount())
+        .approvedCount(createdMeetingProjection.getApprovedCount())
+        .category(foodCategories)
+        .content(createdMeetingProjection.getContent())
+        .thumbnailUrl(createdMeetingProjection.getThumbnailUrl())
+        .build();
+  }
+}

--- a/src/main/java/com/momo/meeting/dto/createdMeeting/CreatedMeetingsResponse.java
+++ b/src/main/java/com/momo/meeting/dto/createdMeeting/CreatedMeetingsResponse.java
@@ -1,0 +1,38 @@
+package com.momo.meeting.dto.createdMeeting;
+
+import com.momo.meeting.projection.CreatedMeetingProjection;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreatedMeetingsResponse {
+
+  private List<CreatedMeetingDto> createdMeetingDtos;
+  private Long lastId;
+  private boolean hasNext;
+
+
+  public static CreatedMeetingsResponse of(
+      List<CreatedMeetingProjection> createdMeetingProjections, int pageSize
+  ) {
+    List<CreatedMeetingDto> createdMeetingDtos =
+        CreatedMeetingDto.convertToCreatedMeetingDto(createdMeetingProjections);
+
+    boolean hasNext = createdMeetingDtos.size() > pageSize;
+
+    createdMeetingDtos = hasNext ?
+        createdMeetingDtos.subList(0, pageSize) :
+        createdMeetingDtos.subList(0, createdMeetingDtos.size());
+
+    Long lastId =
+        hasNext ? createdMeetingDtos.get(createdMeetingDtos.size() - 1).getMeetingId() : null;
+
+    return CreatedMeetingsResponse.builder()
+        .lastId(lastId)
+        .createdMeetingDtos(createdMeetingDtos)
+        .hasNext(hasNext)
+        .build();
+  }
+}

--- a/src/main/java/com/momo/meeting/projection/CreatedMeetingProjection.java
+++ b/src/main/java/com/momo/meeting/projection/CreatedMeetingProjection.java
@@ -1,0 +1,35 @@
+package com.momo.meeting.projection;
+
+import com.momo.meeting.constant.MeetingStatus;
+import java.time.LocalDateTime;
+
+public interface CreatedMeetingProjection {
+
+  Long getId();
+
+  Long getMeetingId();
+
+  MeetingStatus getMeetingStatus();
+
+  String getTitle();
+
+  Long getLocationId();
+
+  Double getLatitude();
+
+  Double getLongitude();
+
+  String getAddress();
+
+  LocalDateTime getMeetingDateTime();
+
+  Integer getMaxCount();
+
+  Integer getApprovedCount();
+
+  String getCategory();
+
+  String getContent();
+
+  String getThumbnailUrl();
+}

--- a/src/main/java/com/momo/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/momo/meeting/repository/MeetingRepository.java
@@ -16,7 +16,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
   int countByUser_IdAndCreatedAtBetween(
       Long userId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
-  // 모집글 목록을 meeting_date_time을 기준으로 오름차순 정렬하여 반환 (커서 기반)
+  // 모집글 목록을 meeting_date_time 을 기준으로 오름차순 정렬하여 반환 (커서 기반)
   @Query(value =
       "SELECT "
           + "m.id as id, "

--- a/src/main/java/com/momo/meeting/service/MeetingService.java
+++ b/src/main/java/com/momo/meeting/service/MeetingService.java
@@ -2,12 +2,14 @@ package com.momo.meeting.service;
 
 import com.momo.meeting.constant.MeetingStatus;
 import com.momo.meeting.constant.SortType;
+import com.momo.meeting.dto.createdMeeting.CreatedMeetingsResponse;
 import com.momo.meeting.dto.create.MeetingCreateRequest;
 import com.momo.meeting.dto.create.MeetingCreateResponse;
 import com.momo.meeting.dto.MeetingsRequest;
 import com.momo.meeting.dto.MeetingsResponse;
 import com.momo.meeting.exception.MeetingErrorCode;
 import com.momo.meeting.exception.MeetingException;
+import com.momo.meeting.projection.CreatedMeetingProjection;
 import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
 import com.momo.user.entity.User;
 import com.momo.meeting.entity.Meeting;
@@ -92,7 +94,6 @@ public class MeetingService {
     );
   }
 
-
   private void validateDailyPostLimit(Long userId) {
     LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
     LocalDateTime endOfDay = startOfDay.plusDays(1);
@@ -113,5 +114,16 @@ public class MeetingService {
       throw new MeetingException(MeetingErrorCode.NOT_MEETING_OWNER);
     }
     return meeting;
+  }
+
+  public CreatedMeetingsResponse getCreatedMeetings(Long userId, Long lastId, int pageSize) {
+    List<CreatedMeetingProjection> createdMeetings =
+        meetingRepository.findAllByUser_IdOrderByCreatedAtAsc(userId, lastId, pageSize + 1);
+    // 다음 페이지 존재 여부를 알기 위해 + 1
+
+    return CreatedMeetingsResponse.of(
+        createdMeetings,
+        pageSize
+    );
   }
 }

--- a/src/main/java/com/momo/participation/dto/AppliedMeetingDto.java
+++ b/src/main/java/com/momo/participation/dto/AppliedMeetingDto.java
@@ -31,6 +31,18 @@ public class AppliedMeetingDto {
   private String content;
   private String thumbnailUrl;
 
+  public static List<AppliedMeetingDto> convertToAppliedMeetingDtos(
+      List<AppliedMeetingProjection> appliedMeetingProjections
+  ) {
+    List<AppliedMeetingDto> appliedMeetingDtos = new ArrayList<>();
+
+    for (AppliedMeetingProjection appliedMeetingProjection : appliedMeetingProjections) {
+      AppliedMeetingDto appliedMeeting = AppliedMeetingDto.from(appliedMeetingProjection);
+      appliedMeetingDtos.add(appliedMeeting);
+    }
+    return appliedMeetingDtos;
+  }
+
   public static AppliedMeetingDto from(AppliedMeetingProjection appliedMeeting) {
     Set<String> foodCategories = FoodCategory.convertToFoodCategories(appliedMeeting.getCategory());
 
@@ -51,17 +63,5 @@ public class AppliedMeetingDto {
         .content(appliedMeeting.getContent())
         .thumbnailUrl(appliedMeeting.getThumbnailUrl())
         .build();
-  }
-
-  public static List<AppliedMeetingDto> convertToAppliedMeetingDtos(
-      List<AppliedMeetingProjection> appliedMeetingProjections
-  ) {
-    List<AppliedMeetingDto> appliedMeetingDtos = new ArrayList<>();
-
-    for (AppliedMeetingProjection appliedMeetingProjection : appliedMeetingProjections) {
-      AppliedMeetingDto appliedMeeting = AppliedMeetingDto.from(appliedMeetingProjection);
-      appliedMeetingDtos.add(appliedMeeting);
-    }
-    return appliedMeetingDtos;
   }
 }

--- a/src/main/java/com/momo/participation/service/ParticipationService.java
+++ b/src/main/java/com/momo/participation/service/ParticipationService.java
@@ -65,21 +65,12 @@ public class ParticipationService {
 
   public AppliedMeetingsResponse getAppliedMeetings(Long userId, Long lastId, int pageSize) {
     List<AppliedMeetingProjection> appliedMeetingsProjections =
-        getAppliedMeetingsProjections(userId, lastId, pageSize);
+        participationRepository.findAppliedMeetingsWithLastId(userId, lastId, pageSize + 1);
+    // 다음 페이지 존재 여부를 알기 위해 + 1
 
     return AppliedMeetingsResponse.of(
         appliedMeetingsProjections,
         pageSize
-    );
-  }
-
-  private List<AppliedMeetingProjection> getAppliedMeetingsProjections(
-      Long userId, Long lastId, int pageSize
-  ) {
-    return participationRepository.findAppliedMeetingsWithLastId(
-        userId,
-        lastId,
-        pageSize + 1// 다음 페이지 존재 여부를 알기 위해 + 1
     );
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #87 

## 📝 변경 사항
### AS-IS
- 개최한 모임 목록 조회 기능 부재

### TO-BE
- 개최한 모임 목록 조회 기능 구현
- 커서 기반 구현

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 초기 요청
![get-created-meetings_1](https://github.com/user-attachments/assets/1950e061-6d4c-43a9-ae19-8596432a15d0)
- 다음 요청
![get-created-meetings_2](https://github.com/user-attachments/assets/5fbf05c9-ac53-4982-a828-f6abeca0dae2)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.