### PR TITLE
[Feature] 모임 신청 취소 기능 구현

### DIFF
--- a/src/main/java/com/momo/meeting/controller/MeetingController.java
+++ b/src/main/java/com/momo/meeting/controller/MeetingController.java
@@ -90,6 +90,6 @@ public class MeetingController {
       @PathVariable Long meetingId
   ) {
     meetingService.deleteMeeting(customUserDetails.getId(), meetingId);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/momo/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/momo/meeting/exception/MeetingErrorCode.java
@@ -15,6 +15,8 @@ public enum MeetingErrorCode {
   DAILY_POSTING_LIMIT_EXCEEDED(
       "하루 포스팅 개수 제한을 초과하였습니다.", HttpStatus.TOO_MANY_REQUESTS),
 
+  INVALID_MEETING_STATUS("유효한 모임 상태가 아닙니다.", HttpStatus.BAD_REQUEST),
+
   INVALID_MEETING_DATE_TIME(
       "유효한 모임 시간이 아닙니다.", HttpStatus.BAD_REQUEST),
 

--- a/src/main/java/com/momo/notification/controller/NotificationController.java
+++ b/src/main/java/com/momo/notification/controller/NotificationController.java
@@ -51,7 +51,7 @@ public class NotificationController {
       @PathVariable Long notificationId
   ) {
     notificationService.deleteNotification(customUserDetails.getId(), notificationId);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   /**
@@ -62,6 +62,6 @@ public class NotificationController {
       @AuthenticationPrincipal CustomUserDetails customUserDetails
   ) {
     notificationService.deleteAllNotifications(customUserDetails.getId());
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/momo/participation/constant/ParticipationStatus.java
+++ b/src/main/java/com/momo/participation/constant/ParticipationStatus.java
@@ -6,11 +6,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ParticipationStatus {
-  PENDING("승인 대기"),
-  APPROVED("승인 완료"),
-  REJECTED("승인 거부"),
-  CLOSED("모집 완료"),
-  CANCELED("모집 취소");
+  PENDING("승인 대기"), // 모임 신청 취소 가능
+  APPROVED("승인 완료"), // 모임(채팅방) 나가기 가능
+  REJECTED("승인 거부"), // 참여한 모집글 목록에서 제거 가능
+  CLOSED("모집 완료"), // 참여한 모집글 목록에서 제거 가능
+  CANCELED("모집 취소"); // 참여한 모집글 목록에서 제거 가능
 
   private final String description;
 }

--- a/src/main/java/com/momo/participation/controller/ParticipationController.java
+++ b/src/main/java/com/momo/participation/controller/ParticipationController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,5 +43,14 @@ public class ParticipationController {
         customUserDetails.getId(), lastId, pageSize
     );
     return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/{participationId}/cancel")
+  public ResponseEntity<Void> cancelParticipation(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PathVariable Long participationId
+  ) {
+    participationService.cancelParticipation(customUserDetails.getId(), participationId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/momo/participation/entity/Participation.java
+++ b/src/main/java/com/momo/participation/entity/Participation.java
@@ -49,4 +49,12 @@ public class Participation extends BaseEntity {
         .participationStatus(ParticipationStatus.PENDING)
         .build();
   }
+
+  public boolean isOwner(Long userId) {
+    return this.user.getId().equals(userId);
+  }
+
+  public Long getMeetingId() {
+    return this.meeting.getId();
+  }
 }

--- a/src/main/java/com/momo/participation/exception/ParticipationErrorCode.java
+++ b/src/main/java/com/momo/participation/exception/ParticipationErrorCode.java
@@ -8,10 +8,16 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ParticipationErrorCode {
 
+  PARTICIPATION_NOT_FOUND("신청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
   INVALID_MEETING_STATUS("신청할 수 없는 모임 상태입니다.", HttpStatus.BAD_REQUEST),
+
+  INVALID_PARTICIPATION_STATUS("유효하지 않은 참여 상태입니다.", HttpStatus.BAD_REQUEST),
 
   PARTICIPATE_SELF_MEETING_NOT_ALLOW(
       "본인이 개설한 모임에는 참여 신청을 할 수 없습니다.", HttpStatus.FORBIDDEN),
+
+  NOT_PARTICIPATION_OWNER("해당 참여 신청의 신청자가 아닙니다.", HttpStatus.FORBIDDEN),
 
   ALREADY_PARTICIPATE_MEETING("이미 참여 신청한 모임입니다.", HttpStatus.CONFLICT);
 

--- a/src/main/java/com/momo/participation/service/ParticipationService.java
+++ b/src/main/java/com/momo/participation/service/ParticipationService.java
@@ -1,12 +1,13 @@
 package com.momo.participation.service;
 
+import com.momo.meeting.constant.MeetingStatus;
 import com.momo.meeting.entity.Meeting;
 import com.momo.meeting.exception.MeetingErrorCode;
 import com.momo.meeting.exception.MeetingException;
 import com.momo.meeting.repository.MeetingRepository;
 import com.momo.notification.constant.NotificationType;
 import com.momo.notification.service.NotificationService;
-import com.momo.participation.dto.AppliedMeetingDto;
+import com.momo.participation.constant.ParticipationStatus;
 import com.momo.participation.dto.AppliedMeetingsResponse;
 import com.momo.participation.entity.Participation;
 import com.momo.participation.exception.ParticipationErrorCode;
@@ -45,8 +46,7 @@ public class ParticipationService {
   }
 
   private Meeting validateForParticipate(Long userId, Long meetingId) {
-    Meeting meeting = meetingRepository.findById(meetingId)
-        .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
+    Meeting meeting = findByMeetingId(meetingId);
 
     if (!meeting.getMeetingStatus().isParticipate()) { // 참여 가능한 상태의 모임글인지 검증
       throw new ParticipationException(ParticipationErrorCode.INVALID_MEETING_STATUS);
@@ -81,5 +81,40 @@ public class ParticipationService {
         lastId,
         pageSize + 1// 다음 페이지 존재 여부를 알기 위해 + 1
     );
+  }
+
+  public void cancelParticipation(Long userId, Long participationId) {
+    Participation participation = validateForCancelParticipation(userId, participationId);
+    participationRepository.delete(participation);
+  }
+
+  private Participation validateForCancelParticipation(Long userId, Long participationId) {
+    // 참여 신청이 존재하는지 검증
+    Participation participation = participationRepository.findById(participationId)
+        .orElseThrow(() ->
+            new ParticipationException(ParticipationErrorCode.PARTICIPATION_NOT_FOUND));
+
+    // 참여 신청의 주인인지 검증
+    if (!participation.isOwner(userId)) {
+      throw new ParticipationException(ParticipationErrorCode.NOT_PARTICIPATION_OWNER);
+    }
+
+    // 참여 신청을 취소할 수 있는 상태인지 검증
+    if (!(participation.getParticipationStatus() == ParticipationStatus.PENDING)) {
+      throw new ParticipationException(ParticipationErrorCode.INVALID_PARTICIPATION_STATUS);
+    }
+
+    Meeting meeting = findByMeetingId(participation.getMeetingId()); // 모임이 존재하는지 검증
+
+    // 모임 상태가 모임 신청을 취소할 수 있는 상태인지 검증
+    if (!(meeting.getMeetingStatus() == MeetingStatus.RECRUITING)) {
+      throw new MeetingException(MeetingErrorCode.INVALID_MEETING_STATUS);
+    }
+    return participation;
+  }
+
+  private Meeting findByMeetingId(Long meetingId) {
+    return meetingRepository.findById(meetingId)
+        .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #89 

## 📝 변경 사항
### AS-IS
- 모임 신청 취소 기능 부재

### TO-BE
- 모임 신청 취소 기능 구현
  1. 해당 모임 신청이 존재하는지 검증
  2. 해당 모임 신청이 해당 회원이 신청한 모임 신청이 맞는지 검증
  3. 해당 모임 신청 상태가 "PENDING"인지 검증
  4. 모임이 존재하는지 검증
  5. 모임의 상태가 "RECRUITING"인지 검증
  6. 모임 신청 삭제

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 취소할 수 없는 모임 신청 상태일 때
![delete-cancel-participation_fail_1](https://github.com/user-attachments/assets/6bbb8293-20f3-45fb-8a51-0c8981fedac7)
- 해당 참여 신청의 신청자가 아닐 때
![delete-cancel-participation_fail_2](https://github.com/user-attachments/assets/8272c684-cb12-464b-9e14-a19aebf4164e)
- 성공
![delete-cancel-participation_success](https://github.com/user-attachments/assets/5470f6cb-0254-4d2b-9b25-1d0763313a88)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.