### PR TITLE
[feature] 타인 프로필 조회 기능

### DIFF
--- a/src/main/java/com/momo/user/controller/UserController.java
+++ b/src/main/java/com/momo/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.momo.user.controller;
 
 import com.momo.user.dto.EmailRequest;
+import com.momo.user.dto.OtherUserInfoResponse;
 import com.momo.user.dto.PasswordResetRequest;
 import com.momo.user.dto.UserInfoResponse;
 import com.momo.user.dto.UserUpdateRequest;
@@ -16,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -78,4 +80,11 @@ public class UserController {
     userService.updateUser(updateRequest);
     return ResponseEntity.ok("회원정보가 성공적으로 수정되었습니다.");
   }
+
+  @GetMapping("/{userId}")
+  public ResponseEntity<OtherUserInfoResponse> getOtherUserProfile(@PathVariable Long userId) {
+    OtherUserInfoResponse userProfile = userService.getOtherUserProfile(userId);
+    return ResponseEntity.ok(userProfile);
+  }
+
 }

--- a/src/main/java/com/momo/user/dto/OtherUserInfoResponse.java
+++ b/src/main/java/com/momo/user/dto/OtherUserInfoResponse.java
@@ -1,0 +1,22 @@
+package com.momo.user.dto;
+
+import com.momo.profile.constant.Gender;
+import com.momo.profile.constant.Mbti;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OtherUserInfoResponse {
+  private String nickname;
+  private Gender gender;
+  private LocalDate birth;
+  private Mbti mbti;
+  private String introduction;
+}

--- a/src/main/java/com/momo/user/service/UserService.java
+++ b/src/main/java/com/momo/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.momo.user.dto.CustomUserDetails;
 import com.momo.auth.dto.KakaoProfile;
 import com.momo.auth.dto.LoginDTO;
 import com.momo.auth.dto.OAuthToken;
+import com.momo.user.dto.OtherUserInfoResponse;
 import com.momo.user.dto.UserInfoResponse;
 import com.momo.user.dto.UserUpdateRequest;
 import com.momo.user.entity.User;
@@ -296,6 +297,26 @@ public class UserService {
     profileRepository.save(profile);
 
     log.debug("User and Profile updated successfully for email: {}", email);
+  }
+
+  @Transactional
+  public OtherUserInfoResponse getOtherUserProfile(Long userId) {
+    // User 엔티티 조회
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    // Profile 엔티티 조회
+    Profile profile = profileRepository.findByUser(user)
+        .orElseThrow(() -> new CustomException(ErrorCode.PROFILE_NOT_FOUND));
+
+    // 필요한 정보만 반환
+    return OtherUserInfoResponse.builder()
+        .nickname(user.getNickname())
+        .gender(profile.getGender())
+        .birth(profile.getBirth())
+        .mbti(profile.getMbti())
+        .introduction(profile.getIntroduction())
+        .build();
   }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Relates to: #84 
- Close to: #84 

## 📝 변경 사항
### AS-IS
- 타인의 간단 정보를 조회할 수 있다.
- 조회 항목 : 닉네님, 성별, MBTI, 나이, 자기소개

### TO-BE
- 타인의 프로필 정보를 담는OtherUserInfoResponse 생성
- UserController 파일에 타인의 프로필을 조회하는 API 호출주소 "/{userId}" 추가
- UserService 파일에  타인의 프로필 정보를 반환하는 getOtherUserProfile 로직 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 타인의 프로필 조회 (일반 로그인 회원)
<img width="744" alt="타인 프로필 조회 (일반 로그인 회원)" src="https://github.com/user-attachments/assets/37135a1d-18fc-481d-8a3d-a45c8a12461e" />

- 타인의 프로필 조회 (카카오 로그인 회원)
<img width="744" alt="타인 프로필 조회 (카카오 로그인 회원)" src="https://github.com/user-attachments/assets/fb4df5c5-b3ab-4335-a8c6-f2f46c087d45" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.