### PR TITLE
[Feature] 모임 참여 신청 승인/거절

### DIFF
--- a/src/main/java/com/momo/notification/constant/NotificationType.java
+++ b/src/main/java/com/momo/notification/constant/NotificationType.java
@@ -8,14 +8,14 @@ import lombok.RequiredArgsConstructor;
 public enum NotificationType {
 
   // 모임 관련 (주최자)
-  NEW_PARTICIPATION_REQUEST("새로운 참가 신청", NotificationCategory.MEETING),
+  NEW_PARTICIPATION_REQUEST("님이 모임 참여를 신청했습니다.", NotificationCategory.MEETING),
 
   PARTICIPANT_LEFT("참가자 탈퇴", NotificationCategory.MEETING),
 
   // 모임 관련 (참가자)
-  PARTICIPANT_APPROVED("참가 승인", NotificationCategory.MEETING),
+  PARTICIPANT_APPROVED("모임에 참여가 승인되었습니다.", NotificationCategory.MEETING),
 
-  PARTICIPANT_REJECTED("참가 거절", NotificationCategory.MEETING),
+  PARTICIPANT_REJECTED("모임에 참여가 거절되었습니다.", NotificationCategory.MEETING),
 
   PARTICIPANT_KICKED("강퇴", NotificationCategory.MEETING),
 

--- a/src/main/java/com/momo/participation/controller/ParticipationController.java
+++ b/src/main/java/com/momo/participation/controller/ParticipationController.java
@@ -1,10 +1,8 @@
 package com.momo.participation.controller;
 
-import com.momo.participation.constant.ParticipationStatus;
 import com.momo.participation.dto.AppliedMeetingsResponse;
 import com.momo.participation.service.ParticipationService;
 import com.momo.user.dto.CustomUserDetails;
-import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.http.HttpStatus;
@@ -15,7 +13,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,6 +29,7 @@ public class ParticipationController {
    *
    * @param customUserDetails 회원 정보
    * @param meetingId         참여 신청할 모임 ID
+   * @return 201 Created
    */
   @PostMapping("/{meetingId}")
   public ResponseEntity<Void> createParticipation(
@@ -65,16 +63,36 @@ public class ParticipationController {
     return ResponseEntity.ok(response);
   }
 
-  // TODO: 참여 승인과 참여 거절로 분리
-  @PatchMapping("/{participationId}")
-  public ResponseEntity<Void> updateParticipationStatus(
+  /**
+   * 참여 신청 승인
+   *
+   * @param customUserDetails 회원 정보
+   * @param participationId   참여 신청 ID
+   * @return 200 OK
+   */
+  @PatchMapping("/{participationId}/approve")
+  public ResponseEntity<Void> approveParticipation(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @PathVariable Long participationId,
-      @RequestBody @NotNull ParticipationStatus participationStatus
+      @PathVariable Long participationId
   ) {
-    participationService.updateParticipationStatus(
-        customUserDetails.getId(), participationId, participationStatus
-    );
+    participationService.approveParticipation(customUserDetails.getId(), participationId);
+    return ResponseEntity.ok()
+        .build();
+  }
+
+  /**
+   * 참여 신청 거절
+   *
+   * @param customUserDetails 회원 정보
+   * @param participationId   참여 신청 ID
+   * @return 200 OK
+   */
+  @PatchMapping("/{participationId}/reject")
+  public ResponseEntity<Void> rejectParticipation(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PathVariable Long participationId
+  ) {
+    participationService.rejectParticipation(customUserDetails.getId(), participationId);
     return ResponseEntity.ok()
         .build();
   }

--- a/src/main/java/com/momo/participation/entity/Participation.java
+++ b/src/main/java/com/momo/participation/entity/Participation.java
@@ -54,8 +54,8 @@ public class Participation extends BaseEntity {
     this.participationStatus = newStatus;
   }
 
-  public boolean isMeetingOwner(Long meetingOwnerId) {
-    return this.meeting.getUser().getId().equals(meetingOwnerId);
+  public boolean isMeetingAuthor(Long authorId) {
+    return this.meeting.getUser().getId().equals(authorId);
   }
   
   public boolean isOwner(Long userId) {

--- a/src/main/java/com/momo/participation/service/ParticipationService.java
+++ b/src/main/java/com/momo/participation/service/ParticipationService.java
@@ -24,9 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ParticipationService {
 
-  private static final String PARTICIPATION_NOTIFICATION_MESSAGE =
-      "님이 모임 참여를 신청했습니다.";
-
   private final ParticipationRepository participationRepository;
   private final MeetingRepository meetingRepository;
   private final NotificationService notificationService;
@@ -40,7 +37,7 @@ public class ParticipationService {
     // 모임 주최자에게 새로운 참여 알림 발송
     notificationService.sendNotification(
         meeting.getUser(),
-        user.getNickname() + PARTICIPATION_NOTIFICATION_MESSAGE,
+        user.getNickname() + NotificationType.NEW_PARTICIPATION_REQUEST.getDescription(),
         NotificationType.NEW_PARTICIPATION_REQUEST
     );
   }
@@ -113,6 +110,14 @@ public class ParticipationService {
   public void approveParticipation(Long authorId, Long participationId) {
     Participation participation = validateForParticipationOwner(authorId, participationId);
     participation.updateStatus(ParticipationStatus.APPROVED);
+
+    // 참여 신청을 보낸 회원에게 알림 발송
+    notificationService.sendNotification(
+        participation.getUser(),
+        participation.getMeeting().getTitle()
+            + NotificationType.PARTICIPANT_APPROVED.getDescription(),
+        NotificationType.PARTICIPANT_APPROVED
+    );
     // TODO: 참여 승인되면 채팅방 입장
   }
 
@@ -120,6 +125,14 @@ public class ParticipationService {
   public void rejectParticipation(Long authorId, Long participationId) {
     Participation participation = validateForParticipationOwner(authorId, participationId);
     participation.updateStatus(ParticipationStatus.REJECTED);
+
+    // 참여 신청을 보낸 회원에게 알림 발송
+    notificationService.sendNotification(
+        participation.getUser(),
+        participation.getMeeting().getTitle()
+            + NotificationType.PARTICIPANT_REJECTED.getDescription(),
+        NotificationType.PARTICIPANT_REJECTED
+    );
   }
 
   private Participation validateForParticipationOwner(Long authorId, Long participationId) {

--- a/src/main/java/com/momo/participation/service/ParticipationService.java
+++ b/src/main/java/com/momo/participation/service/ParticipationService.java
@@ -133,7 +133,7 @@ public class ParticipationService {
       throw new ParticipationException(ParticipationErrorCode.INVALID_PARTICIPATION_STATUS);
     }
 
-    // 현재 회원이 해당 모임 신청을 받은 모임글의 작성자인지 검증
+    // 현재 회원이 해당 모임 신청을 받은 모임의 작성자인지 검증
     if (!participation.isMeetingAuthor(authorId)) {
       throw new MeetingException(MeetingErrorCode.NOT_MEETING_OWNER);
     }

--- a/src/test/java/com/momo/participation/service/ParticipationServiceTest.java
+++ b/src/test/java/com/momo/participation/service/ParticipationServiceTest.java
@@ -199,6 +199,11 @@ class ParticipationServiceTest {
     assertEquals(MeetingStatus.RECRUITING, meeting.getMeetingStatus());
     assertEquals(ParticipationStatus.APPROVED, participation.getParticipationStatus());
     verify(participationRepository).findById(participation.getId());
+    verify(notificationService).sendNotification(
+        participation.getUser(),
+        participation.getMeeting().getTitle()
+            + NotificationType.PARTICIPANT_APPROVED.getDescription(),
+        NotificationType.PARTICIPANT_APPROVED);
   }
 
   @Test
@@ -220,6 +225,11 @@ class ParticipationServiceTest {
     assertEquals(MeetingStatus.RECRUITING, meeting.getMeetingStatus());
     assertEquals(ParticipationStatus.REJECTED, participation.getParticipationStatus());
     verify(participationRepository).findById(participation.getId());
+    verify(notificationService).sendNotification(
+        participation.getUser(),
+        participation.getMeeting().getTitle()
+            + NotificationType.PARTICIPANT_REJECTED.getDescription(),
+        NotificationType.PARTICIPANT_REJECTED);
   }
 
   private static User createUser(Long userId) {

--- a/src/test/java/com/momo/participation/service/ParticipationServiceTest.java
+++ b/src/test/java/com/momo/participation/service/ParticipationServiceTest.java
@@ -181,25 +181,44 @@ class ParticipationServiceTest {
   }
 
   @Test
-  @DisplayName("모임 참여 신청 상태 변경  - 성공")
-  void updateMeetingStatus_Success() {
+  @DisplayName("참여 신청 승인  - 성공")
+  void approveParticipation_Success() {
     // given
     User user = createUser(1L);
-    User meetingOwner = createUser(2L);
-    Meeting meeting = createMeeting(meetingOwner, MeetingStatus.RECRUITING);
+    User author = createUser(2L);
+    Meeting meeting = createMeeting(author, MeetingStatus.RECRUITING);
     Participation participation = createParticipation(user, meeting);
 
     when(participationRepository.findById(participation.getId()))
         .thenReturn(Optional.of(participation));
 
     // when
-    participationService.updateParticipationStatus(
-        meetingOwner.getId(), participation.getId(), ParticipationStatus.APPROVED
-    );
+    participationService.approveParticipation(author.getId(), participation.getId());
 
     // then
     assertEquals(MeetingStatus.RECRUITING, meeting.getMeetingStatus());
     assertEquals(ParticipationStatus.APPROVED, participation.getParticipationStatus());
+    verify(participationRepository).findById(participation.getId());
+  }
+
+  @Test
+  @DisplayName("참여 신청 거절  - 성공")
+  void rejectParticipation_Success() {
+    // given
+    User user = createUser(1L);
+    User author = createUser(2L);
+    Meeting meeting = createMeeting(author, MeetingStatus.RECRUITING);
+    Participation participation = createParticipation(user, meeting);
+
+    when(participationRepository.findById(participation.getId()))
+        .thenReturn(Optional.of(participation));
+
+    // when
+    participationService.rejectParticipation(author.getId(), participation.getId());
+
+    // then
+    assertEquals(MeetingStatus.RECRUITING, meeting.getMeetingStatus());
+    assertEquals(ParticipationStatus.REJECTED, participation.getParticipationStatus());
     verify(participationRepository).findById(participation.getId());
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #96 

## 📝 변경 사항
### AS-IS
- 모임 참여 신청 상태 변경 관련 로직이 하나의 메서드로 통합돼 있음
- 알림 발송 로직 부재

### TO-BE
- 하나의 로직을 승인과 거절로 메서드로 엔드포인트 분리
- 승인 및 거절 메서드에 알림 발송 로직 추가

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 존재하지 않는 참여 신청을 요청했을 때
![patch-approve-participation_error_1](https://github.com/user-attachments/assets/247c6ba7-26f0-4535-9b2c-5297378990ac)
- 해당 모임의 작성자가 아닌 회원이 승인 또는 거절을 요청을 했을 때
![patch-approve-participation_error_2](https://github.com/user-attachments/assets/a82ef32a-3e1a-4b3e-9b5f-7bf29847a3fb)
- 참여 신청의 상태가 "PENDING"이 아닐 때
![patch-approve-participation_error_3](https://github.com/user-attachments/assets/0d7a2a7b-f409-4fb5-9090-b8afaf4da4c0)
- 성공
![patch-approve-participation_success](https://github.com/user-attachments/assets/f43cb138-cdd1-4d7b-851b-ecc512073194)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.