### PR TITLE
[Feature] 모임 참여 신청자 목록 조회

### DIFF
--- a/src/main/java/com/momo/meeting/controller/MeetingController.java
+++ b/src/main/java/com/momo/meeting/controller/MeetingController.java
@@ -6,10 +6,12 @@ import com.momo.meeting.dto.create.MeetingCreateRequest;
 import com.momo.meeting.dto.create.MeetingCreateResponse;
 import com.momo.meeting.dto.MeetingsRequest;
 import com.momo.meeting.dto.MeetingsResponse;
+import com.momo.meeting.projection.MeetingParticipantProjection;
 import com.momo.meeting.service.MeetingService;
 import com.momo.user.dto.CustomUserDetails;
 import java.net.URI;
 import java.time.LocalDateTime;
+import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -98,6 +100,24 @@ public class MeetingController {
   ) {
     CreatedMeetingsResponse response =
         meetingService.getCreatedMeetings(customUserDetails.getId(), lastId, pageSize);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 모임 참여 신청자 목로 조회
+   *
+   * @param customUserDetails 회원 정보
+   * @param meetingId         모임 ID
+   * @return 참여 신정자의 ID, 닉네임, 프로필 사진 URL, 참여 상태를 담은 List 반환
+   */
+  @GetMapping("/{meetingId}/participants")
+  public ResponseEntity<List<MeetingParticipantProjection>> getMeetingParticipant(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @PathVariable Long meetingId
+  ) {
+    List<MeetingParticipantProjection> response =
+        meetingService.getParticipants(customUserDetails.getId(), meetingId);
+
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/com/momo/meeting/entity/Meeting.java
+++ b/src/main/java/com/momo/meeting/entity/Meeting.java
@@ -92,7 +92,7 @@ public class Meeting extends BaseEntity {
     this.category = request.getCategory();
   }
 
-  public boolean isOwner(Long userId) {
+  public boolean isAuthor(Long userId) {
     return this.user.getId().equals(userId);
   }
 }

--- a/src/main/java/com/momo/meeting/projection/MeetingParticipantProjection.java
+++ b/src/main/java/com/momo/meeting/projection/MeetingParticipantProjection.java
@@ -1,0 +1,14 @@
+package com.momo.meeting.projection;
+
+import com.momo.participation.constant.ParticipationStatus;
+
+public interface MeetingParticipantProjection {
+
+  Long getUserId();
+
+  String getNickname();
+
+  String getProfileImageUrl();
+
+  ParticipationStatus getParticipationStatus();
+}

--- a/src/main/java/com/momo/meeting/service/MeetingService.java
+++ b/src/main/java/com/momo/meeting/service/MeetingService.java
@@ -10,7 +10,9 @@ import com.momo.meeting.dto.MeetingsResponse;
 import com.momo.meeting.exception.MeetingErrorCode;
 import com.momo.meeting.exception.MeetingException;
 import com.momo.meeting.projection.CreatedMeetingProjection;
+import com.momo.meeting.projection.MeetingParticipantProjection;
 import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
+import com.momo.participation.repository.ParticipationRepository;
 import com.momo.user.entity.User;
 import com.momo.meeting.entity.Meeting;
 import com.momo.meeting.repository.MeetingRepository;
@@ -26,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MeetingService {
 
   private final MeetingRepository meetingRepository;
+  private final ParticipationRepository participationRepository;
 
   public MeetingCreateResponse createMeeting(User user, MeetingCreateRequest request) {
     validateDailyPostLimit(user.getId());
@@ -33,6 +36,18 @@ public class MeetingService {
 
     meetingRepository.save(meeting);
     return MeetingCreateResponse.from(meeting);
+  }
+
+  private void validateDailyPostLimit(Long userId) {
+    LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+    LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+    int todayPostCount =
+        meetingRepository.countByUser_IdAndCreatedAtBetween(userId, startOfDay, endOfDay);
+
+    if (todayPostCount >= 10) {
+      throw new MeetingException(MeetingErrorCode.DAILY_POSTING_LIMIT_EXCEEDED);
+    }
   }
 
   public MeetingsResponse getMeetings(MeetingsRequest request) {
@@ -50,12 +65,6 @@ public class MeetingService {
     );
   }
 
-  @Transactional
-  public void updateMeetingStatus(Long userId, Long meetingId, MeetingStatus newStatus) {
-    Meeting meeting = validateForMeetingOwner(userId, meetingId);
-    meeting.updateStatus(newStatus);
-  }
-
   private List<MeetingToMeetingDtoProjection> getNearbyMeetings(MeetingsRequest request) {
     return meetingRepository.findNearbyMeetingsWithCursor(
         request.getUserLatitude(),
@@ -65,6 +74,19 @@ public class MeetingService {
         request.getCursorDistance(),
         request.getPageSize() + 1 // 다음 페이지 존재 여부를 알기 위해 + 1
     );
+  }
+
+  private List<MeetingToMeetingDtoProjection> getMeetingsByDate(MeetingsRequest request) {
+    return meetingRepository.findOrderByMeetingDateWithCursor(
+        request.getCursorId(),
+        request.getCursorMeetingDateTime(),
+        request.getPageSize() + 1 // 다음 페이지 존재 여부를 알기 위해 + 1
+    );
+  }
+
+  public List<MeetingParticipantProjection> getParticipants(Long userId, Long meetingId) {
+    validateForMeetingOwner(userId, meetingId);
+    return participationRepository.findMeetingParticipantsByMeeting_Id(meetingId);
   }
 
   @Transactional
@@ -77,36 +99,22 @@ public class MeetingService {
     return MeetingCreateResponse.from(meeting);
   }
 
+  @Transactional
+  public void updateMeetingStatus(Long userId, Long meetingId, MeetingStatus newStatus) {
+    Meeting meeting = validateForMeetingOwner(userId, meetingId);
+    meeting.updateStatus(newStatus);
+  }
+
   public void deleteMeeting(Long userId, Long meetingId) {
     Meeting meeting = validateForMeetingOwner(userId, meetingId);
     meetingRepository.delete(meeting);
-  }
-
-  private List<MeetingToMeetingDtoProjection> getMeetingsByDate(MeetingsRequest request) {
-    return meetingRepository.findOrderByMeetingDateWithCursor(
-        request.getCursorId(),
-        request.getCursorMeetingDateTime(),
-        request.getPageSize() + 1 // 다음 페이지 존재 여부를 알기 위해 + 1
-    );
-  }
-
-  private void validateDailyPostLimit(Long userId) {
-    LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
-    LocalDateTime endOfDay = startOfDay.plusDays(1);
-
-    int todayPostCount =
-        meetingRepository.countByUser_IdAndCreatedAtBetween(userId, startOfDay, endOfDay);
-    
-    if (todayPostCount >= 10) {
-      throw new MeetingException(MeetingErrorCode.DAILY_POSTING_LIMIT_EXCEEDED);
-    }
   }
 
   private Meeting validateForMeetingOwner(Long userId, Long meetingId) {
     Meeting meeting = meetingRepository.findById(meetingId)
         .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
 
-    if (!meeting.isOwner(userId)) {
+    if (!meeting.isAuthor(userId)) {
       throw new MeetingException(MeetingErrorCode.NOT_MEETING_OWNER);
     }
     return meeting;

--- a/src/main/java/com/momo/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/momo/participation/repository/ParticipationRepository.java
@@ -1,5 +1,6 @@
 package com.momo.participation.repository;
 
+import com.momo.meeting.projection.MeetingParticipantProjection;
 import com.momo.participation.entity.Participation;
 import com.momo.participation.projection.AppliedMeetingProjection;
 import java.util.List;
@@ -46,5 +47,21 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
       @Param("userId") Long userId,
       @Param("lastId") Long lastId,
       @Param("pageSize") int pageSize
+  );
+
+  // 해당 모임에 참여 신청한 회원 목록을 조회
+  @Query(value = "SELECT "
+      + "u.user_id as userId, "
+      + "u.nickname as nickname, "
+      + "p.profile_image_url as profileImageUrl, "
+      + "mp.participation_status as participationStatus "
+      + "FROM participation mp "
+      + "JOIN users u ON mp.user_id = u.user_id "
+      + "JOIN profile p ON u.user_id = p.user_id "
+      + "WHERE mp.meeting_id = :meetingId "
+      + "ORDER BY mp.created_at ASC",
+      nativeQuery = true)
+  List<MeetingParticipantProjection> findMeetingParticipantsByMeeting_Id(
+      @Param("meetingId") Long meetingId
   );
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #98 

## 📝 변경 사항
### AS-IS
- 모임 참여 신청자 목록 조회 기능 부재

### TO-BE
- 모임 참여 신청자 목록 조회 기능 추가

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 존재하지 않는 모임일 때
![get-meeting-participants_error_1](https://github.com/user-attachments/assets/e21ed8bf-fd0d-4bd7-9af9-c3e7aea18f8f)
- 해당 모임의 작성자가 아닐 때
![get-meeting-participants_error_2](https://github.com/user-attachments/assets/b6128196-9ca6-47d0-abb7-91e7030a9b56)
- 성공
![get-meeting-participants_success](https://github.com/user-attachments/assets/6882de71-6ad7-4863-b030-8910c150729f)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.