### PR TITLE
[Feature] 모임 승인 시 참여 상태와 모임 인원 동시성 처리 및 채팅방 참여하도록 구현

### DIFF
--- a/src/main/java/com/momo/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/momo/chat/repository/ChatRoomRepository.java
@@ -14,4 +14,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
   List<ChatRoom> findAllByReaderContains(User user);
 
+  Optional<ChatRoom> findByMeeting_Id(Long id);
 }

--- a/src/main/java/com/momo/common/exception/ErrorCode.java
+++ b/src/main/java/com/momo/common/exception/ErrorCode.java
@@ -10,9 +10,11 @@ public enum ErrorCode {
   INVALID_KAKAO_RESPONSE("잘못된 Kakao API 응답입니다.", 400),
   INVALID_REQUEST("잘못된 요청입니다.", 400),
   INVALID_TOKEN("유효하지 않은 토큰입니다.", 400),
-  EMAIL_SEND_FAILED("메일 발송을 실패했습니다.",400),
-  PROFILE_NOT_FOUND("프로필을 찾을 수 없습니다.",400),
-  KAKAO_UNLINK_FAILED("카카오 계정 연동해제를 실패했습니다.",400);
+  EMAIL_SEND_FAILED("메일 발송을 실패했습니다.", 400),
+  PROFILE_NOT_FOUND("프로필을 찾을 수 없습니다.", 400),
+  KAKAO_UNLINK_FAILED("카카오 계정 연동해제를 실패했습니다.", 400),
+  OPTIMISTIC_LOCKING_FAILURE(
+      "이미 다른 처리가 진행되었습니다. 새로고침 후 다시 시도해 주세요.", 400);
 
   private final String message;
   private final int status;

--- a/src/main/java/com/momo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/momo/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,13 @@
 package com.momo.common.exception;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -20,4 +24,12 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus()).body(response);
   }
 
+  @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+  public ResponseEntity<ErrorResponse> handleObjectOptimisticLockingFailureException(
+      ObjectOptimisticLockingFailureException e
+  ) {
+    log.error("Optimistic Locking 실패", e);
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(new ErrorResponse(ErrorCode.OPTIMISTIC_LOCKING_FAILURE));
+  }
 }

--- a/src/main/java/com/momo/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/momo/meeting/exception/MeetingErrorCode.java
@@ -20,7 +20,9 @@ public enum MeetingErrorCode {
   INVALID_MEETING_DATE_TIME(
       "유효한 모임 시간이 아닙니다.", HttpStatus.BAD_REQUEST),
 
-  INVALID_FOOD_CATEGORY("유효한 음식 카테고리가 아닙니다.", HttpStatus.BAD_REQUEST);
+  INVALID_FOOD_CATEGORY("유효한 음식 카테고리가 아닙니다.", HttpStatus.BAD_REQUEST),
+
+  ALREADY_MAX_COUNT("모임 인원이 가득찼습니다.", HttpStatus.CONFLICT);
 
   private final String message;
   private final HttpStatus status;

--- a/src/main/java/com/momo/participation/entity/Participation.java
+++ b/src/main/java/com/momo/participation/entity/Participation.java
@@ -14,6 +14,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,6 +26,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Participation extends BaseEntity {
+
+  @Version
+  private Long version;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,12 +61,20 @@ public class Participation extends BaseEntity {
   public boolean isMeetingAuthor(Long authorId) {
     return this.meeting.getUser().getId().equals(authorId);
   }
-  
-  public boolean isOwner(Long userId) {
+
+  public boolean isAuthor(Long userId) {
     return this.user.getId().equals(userId);
   }
 
   public Long getMeetingId() {
     return this.meeting.getId();
+  }
+
+  public boolean isAcceptableStatus() {
+    return this.participationStatus == ParticipationStatus.PENDING;
+  }
+
+  public Long getUserId() {
+    return this.getUser().getId();
   }
 }

--- a/src/main/java/com/momo/participation/service/ParticipationService.java
+++ b/src/main/java/com/momo/participation/service/ParticipationService.java
@@ -120,8 +120,8 @@ public class ParticipationService {
 
   @Transactional
   public void approveParticipation(Long authorId, Long participationId) {
-    Participation participation = validateMeetingAuthorForParticipation(authorId,
-        participationId);
+    Participation participation =
+        validateMeetingAuthorForParticipation(authorId, participationId);
     Meeting meeting = participation.getMeeting();
 
     validatePossibleParticipant(participation, meeting); // 검증
@@ -137,7 +137,6 @@ public class ParticipationService {
             + NotificationType.PARTICIPANT_APPROVED.getDescription(),
         NotificationType.PARTICIPANT_APPROVED
     );
-    log.info("트랜잭션 종료 전 Meeting(id={}) 최종 승인 수: {}", meeting.getId(), meeting.getApprovedCount());
   }
 
   private void joinChatRoom(Meeting meeting, Participation participation) {


### PR DESCRIPTION
## 📌 관련 이슈
- close #101 

## 📝 변경 사항
### AS-IS
- 동시성 처리 부족
- 참여 승인 시 모임의 현재 인원 증가 처리 부재
- 채팅방 참여 로직 부재

### TO-BE
- 낙관적 락을 통한 동시성 처리
- 참여 승인 시 모임의 현재 인원 1 증가
- 채팅방 참여 로직 추가

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.