### PR TITLE
[Feature] 모임 참여 신청 삭제

### DIFF
--- a/src/main/java/com/momo/meeting/service/MeetingService.java
+++ b/src/main/java/com/momo/meeting/service/MeetingService.java
@@ -1,5 +1,6 @@
 package com.momo.meeting.service;
 
+import com.momo.chat.service.ChatRoomService;
 import com.momo.meeting.constant.MeetingStatus;
 import com.momo.meeting.constant.SortType;
 import com.momo.meeting.dto.MeetingCursor;
@@ -34,59 +35,16 @@ public class MeetingService {
 
   private final MeetingRepository meetingRepository;
   private final ParticipationRepository participationRepository;
+  private final ChatRoomService chatRoomService;
 
   public MeetingCreateResponse createMeeting(User user, MeetingCreateRequest request) {
     validateDailyPostLimit(user.getId());
     Meeting meeting = request.toEntity(request, user);
 
     meetingRepository.save(meeting);
+    chatRoomService.createChatRoom(user.getId(), meeting.getId()); // 채팅방 생성
+
     return MeetingCreateResponse.from(meeting);
-  }
-
-  private void validateDailyPostLimit(Long userId) {
-    LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
-    LocalDateTime endOfDay = startOfDay.plusDays(1);
-
-    int todayPostCount =
-        meetingRepository.countByUser_IdAndCreatedAtBetween(userId, startOfDay, endOfDay);
-
-    if (todayPostCount >= 10) {
-      throw new MeetingException(MeetingErrorCode.DAILY_POSTING_LIMIT_EXCEEDED);
-    }
-  }
-
-  public MeetingsResponse getMeetings(MeetingsRequest request) {
-    List<MeetingToMeetingDtoProjection> meetingProjections;
-
-    if (request.getSortType() == SortType.DISTANCE) {
-      meetingProjections = getNearbyMeetings(request);
-    } else {
-      meetingProjections = getMeetingsByDate(request);
-    }
-
-    return MeetingsResponse.of(
-        meetingProjections,
-        request.getPageSize()
-    );
-  }
-
-  private List<MeetingToMeetingDtoProjection> getNearbyMeetings(MeetingsRequest request) {
-    return meetingRepository.findNearbyMeetingsWithCursor(
-        request.getUserLatitude(),
-        request.getUserLongitude(),
-        request.getRadius(),
-        request.getCursorId(),
-        request.getCursorDistance(),
-        request.getPageSize() + 1 // 다음 페이지 존재 여부를 알기 위해 + 1
-    );
-  }
-
-  private List<MeetingToMeetingDtoProjection> getMeetingsByDate(MeetingsRequest request) {
-    return meetingRepository.findOrderByMeetingDateWithCursor(
-        request.getCursorId(),
-        request.getCursorMeetingDateTime(),
-        request.getPageSize() + 1 // 다음 페이지 존재 여부를 알기 위해 + 1
-    );
   }
 
   public List<MeetingParticipantProjection> getParticipants(Long userId, Long meetingId) {
@@ -115,14 +73,19 @@ public class MeetingService {
     meetingRepository.delete(meeting);
   }
 
-  private Meeting validateForMeetingOwner(Long userId, Long meetingId) {
-    Meeting meeting = meetingRepository.findById(meetingId)
-        .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
+  public MeetingsResponse getMeetings(MeetingsRequest request) {
+    List<MeetingToMeetingDtoProjection> meetingProjections;
 
-    if (!meeting.isAuthor(userId)) {
-      throw new MeetingException(MeetingErrorCode.NOT_MEETING_OWNER);
+    if (request.getSortType() == SortType.DISTANCE) {
+      meetingProjections = getNearbyMeetings(request);
+    } else {
+      meetingProjections = getMeetingsByDate(request);
     }
-    return meeting;
+
+    return MeetingsResponse.of(
+        meetingProjections,
+        request.getPageSize()
+    );
   }
 
   public CreatedMeetingsResponse getCreatedMeetings(Long userId, Long lastId, int pageSize) {
@@ -175,6 +138,47 @@ public class MeetingService {
 
     List<MeetingDto> filteredMeetings = meetingStream.collect(Collectors.toList());
     return processFilteredMeetings(filteredMeetings, pageSize);
+  }
+
+  private void validateDailyPostLimit(Long userId) {
+    LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+    LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+    int todayPostCount =
+        meetingRepository.countByUser_IdAndCreatedAtBetween(userId, startOfDay, endOfDay);
+
+    if (todayPostCount >= 10) {
+      throw new MeetingException(MeetingErrorCode.DAILY_POSTING_LIMIT_EXCEEDED);
+    }
+  }
+
+  private List<MeetingToMeetingDtoProjection> getNearbyMeetings(MeetingsRequest request) {
+    return meetingRepository.findNearbyMeetingsWithCursor(
+        request.getUserLatitude(),
+        request.getUserLongitude(),
+        request.getRadius(),
+        request.getCursorId(),
+        request.getCursorDistance(),
+        request.getPageSize() + 1 // 다음 페이지 존재 여부를 알기 위해 + 1
+    );
+  }
+
+  private List<MeetingToMeetingDtoProjection> getMeetingsByDate(MeetingsRequest request) {
+    return meetingRepository.findOrderByMeetingDateWithCursor(
+        request.getCursorId(),
+        request.getCursorMeetingDateTime(),
+        request.getPageSize() + 1 // 다음 페이지 존재 여부를 알기 위해 + 1
+    );
+  }
+
+  private Meeting validateForMeetingOwner(Long userId, Long meetingId) {
+    Meeting meeting = meetingRepository.findById(meetingId)
+        .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
+
+    if (!meeting.isAuthor(userId)) {
+      throw new MeetingException(MeetingErrorCode.NOT_MEETING_OWNER);
+    }
+    return meeting;
   }
 
   private MeetingsResponse processFilteredMeetings(

--- a/src/main/java/com/momo/participation/constant/ParticipationStatus.java
+++ b/src/main/java/com/momo/participation/constant/ParticipationStatus.java
@@ -1,5 +1,6 @@
 package com.momo.participation.constant;
 
+import java.util.EnumSet;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,5 +13,13 @@ public enum ParticipationStatus {
   CLOSED("모집 완료"), // 참여한 모집글 목록에서 제거 가능
   CANCELED("모집 취소"); // 참여한 모집글 목록에서 제거 가능
 
+  private static final EnumSet<ParticipationStatus> DELETABLE_STATUS =
+      EnumSet.of(PENDING, REJECTED, CLOSED, CANCELED);
+
   private final String description;
+
+
+  public boolean isDeletable() {
+    return DELETABLE_STATUS.contains(this);
+  }
 }

--- a/src/main/java/com/momo/participation/controller/ParticipationController.java
+++ b/src/main/java/com/momo/participation/controller/ParticipationController.java
@@ -44,7 +44,7 @@ public class ParticipationController {
   }
 
   /**
-   * 참여한 모임 목록 조회
+   * 신청한 모임 목록 조회
    *
    * @param customUserDetails 회원 정보
    * @param lastId            마지막으로 조회된 모임 ID
@@ -98,17 +98,18 @@ public class ParticipationController {
   }
 
   /**
-   * 모임 참여 신청 취소
+   * 모임 참여 삭제
    *
    * @param customUserDetails 회원 정보
-   * @param participationId   참여 신청 ID
+   * @param participationId   모임 참여 ID
+   * @return 204 No Content
    */
-  @DeleteMapping("/{participationId}/cancel")
-  public ResponseEntity<Void> cancelParticipation(
+  @DeleteMapping("/{participationId}")
+  public ResponseEntity<Void> deleteParticipation(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @PathVariable Long participationId
   ) {
-    participationService.cancelParticipation(customUserDetails.getId(), participationId);
+    participationService.deleteParticipation(customUserDetails.getId(), participationId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/momo/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/momo/participation/repository/ParticipationRepository.java
@@ -14,6 +14,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
   boolean existsByUser_IdAndMeeting_Id(Long userId, Long id);
 
+  // 신청한 모임 목록 조회
   @Query(value =
       "SELECT "
           + "p.id as id, "


### PR DESCRIPTION
## 📌 관련 이슈
- close #108 

## 📝 변경 사항
### AS-IS
- 참여 신청 취소 메서드에서 PENDING인 상태만 삭제할 수 있도록 구현돼 있음
- 참여 상태가 REJECTED, CLOSED, CANCELED인 경우 삭제할 수 있는 로직 부재

### TO-BE
- 기존의 참여 신청 취소 메서드를 참여 신청 삭제 메서드와 통합
- 참여 신청이 존재하는지 검증
- 참여 신청의 주인인지 검증
- 참여 신청이 삭제할 수 있는 상태인지 검증
- 참여 상태가 PENDING, REJECTED, CLOSED, CANCELED 중 하나인 경우 삭제 가능하도록 구현

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 시도한 회원이 참여 신청의 신청자가 아닐 경우
![delete-participatoin-error_1](https://github.com/user-attachments/assets/c5d036e3-a25f-44a8-a8fa-3dbe3102dbd7)
- 참여 신청이 존재하지 않는 경우
![delete-participatoin-error_2](https://github.com/user-attachments/assets/3da5fcf0-ea79-4d33-b3c0-8300412a186b)
- 삭제할 수 있는 참여 신청이 아닌 경우
![delete-participatoin-error_3](https://github.com/user-attachments/assets/c363468c-d5b8-463d-826b-0b6bf65c3e70)
- 성공
![delete-participatoin-success](https://github.com/user-attachments/assets/df6b8f7f-bfdd-40eb-9b3f-2fcc9940472d)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.