### PR TITLE
[Fix] 프로필 생성 후 발급되는 토큰으로 로그아웃 시도 시 에러 발생 버그 수정

### DIFF
--- a/src/main/java/com/momo/config/JWTFilter.java
+++ b/src/main/java/com/momo/config/JWTFilter.java
@@ -162,7 +162,8 @@ public class JWTFilter extends OncePerRequestFilter {
 
   private boolean isProfileCheckSkipPath(String path) {
     return isExcludedPath(path) ||
-        path.equals("/api/v1/profiles");
+        path.equals("/api/v1/profiles") ||
+        path.equals("/api/v1/users/logout");
   }
 
   private void sendErrorResponse(HttpServletResponse response, int status, String message)

--- a/src/main/java/com/momo/config/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/momo/config/token/repository/RefreshTokenRepository.java
@@ -39,4 +39,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
   Optional<RefreshToken> findByUser(User user);
 
   void deleteByUser(User user);
+
+  Optional<RefreshToken> findByUser_Id(Long id);
 }

--- a/src/test/java/com/momo/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/momo/profile/service/ProfileServiceTest.java
@@ -8,6 +8,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.momo.config.JWTUtil;
+import com.momo.config.token.entity.RefreshToken;
+import com.momo.config.token.repository.RefreshTokenRepository;
 import com.momo.profile.constant.Gender;
 import com.momo.profile.constant.Mbti;
 import com.momo.profile.dto.ProfileCreateRequest;
@@ -18,6 +21,9 @@ import com.momo.profile.repository.ProfileRepository;
 import com.momo.profile.validation.ProfileValidator;
 import com.momo.user.entity.User;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +37,12 @@ class ProfileServiceTest {
 
   @Mock
   private ProfileRepository profileRepository;
+
+  @Mock
+  private RefreshTokenRepository refreshTokenRepository;
+
+  @Mock
+  private JWTUtil jwtUtil;
 
   @Mock
   private ProfileImageService profileImageService;
@@ -47,16 +59,24 @@ class ProfileServiceTest {
     // given
     ProfileCreateRequest request = createProfileRequest();
     MultipartFile mockImage = mock(MultipartFile.class);
+
     User user = createUser();
     String imageUrl = "test-image-url.jpg";
     Profile profile = request.toEntity(user, imageUrl);
 
+    HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+    RefreshToken refreshToken =
+        RefreshToken.create(user, "test-refresh-token", LocalDateTime.now().plusDays(7));
+
     doNothing().when(profileValidator).validateHasProfile(1L);
     when(profileImageService.getProfileImageUrl(mockImage)).thenReturn(imageUrl);
+
     when(profileRepository.save(any(Profile.class))).thenReturn(profile);
+    when(refreshTokenRepository.findByUser_Id(user.getId())).thenReturn(Optional.of(refreshToken));
 
     // when
-    ProfileCreateResponse response = profileService.createProfile(user, request, mockImage);
+    ProfileCreateResponse response =
+        profileService.createProfile(httpServletResponse, user, request, mockImage);
 
     // then
     verify(profileImageService).getProfileImageUrl(mockImage);
@@ -74,15 +94,23 @@ class ProfileServiceTest {
     // given
     ProfileCreateRequest request = createProfileRequest();
     String imageUrl = "default-image-url.jpg";
+
     User user = createUser();
     Profile profile = request.toEntity(user, imageUrl);
 
+    HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+    RefreshToken refreshToken =
+        RefreshToken.create(user, "test-refresh-token", LocalDateTime.now().plusDays(7));
+
     doNothing().when(profileValidator).validateHasProfile(1L);
     when(profileImageService.getProfileImageUrl(null)).thenReturn(imageUrl);
+
     when(profileRepository.save(any(Profile.class))).thenReturn(profile);
+    when(refreshTokenRepository.findByUser_Id(user.getId())).thenReturn(Optional.of(refreshToken));
 
     // when
-    ProfileCreateResponse response = profileService.createProfile(user, request, null);
+    ProfileCreateResponse response =
+        profileService.createProfile(httpServletResponse, user, request, null);
 
     verify(profileRepository).save(any(Profile.class));
     verify(profileImageService).getProfileImageUrl(null);
@@ -114,12 +142,14 @@ class ProfileServiceTest {
         .introduction("자기소개")
         .mbti(Mbti.ENTJ)
         .build();
+    HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
 
     // when
     doNothing().when(profileValidator).validateHasProfile(1L);
 
     // then
-    assertThatThrownBy(() -> profileService.createProfile(user, request, null))
+    assertThatThrownBy(() ->
+        profileService.createProfile(httpServletResponse, user, request, null))
         .isInstanceOf(ProfileException.class);
   }
 
@@ -134,10 +164,12 @@ class ProfileServiceTest {
         .introduction("자기소개")
         .mbti(Mbti.ENTJ)
         .build();
+    HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
 
     // when
     // then
-    assertThatThrownBy(() -> profileService.createProfile(user, request, null))
+    assertThatThrownBy(() ->
+        profileService.createProfile(httpServletResponse, user, request, null))
         .isInstanceOf(ProfileException.class);
   }
 
@@ -152,16 +184,18 @@ class ProfileServiceTest {
         .introduction("자기소개")
         .mbti(Mbti.ENTJ)
         .build();
+    HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
 
     // when
     doNothing().when(profileValidator).validateHasProfile(1L);
 
     // then
-    assertThatThrownBy(() -> profileService.createProfile(user, request, null))
+    assertThatThrownBy(() ->
+        profileService.createProfile(httpServletResponse, user, request, null))
         .isInstanceOf(ProfileException.class);
   }
 
-  User createUser(){
+  User createUser() {
     return User.builder()
         .id(1L)
         .email("test@gmail.com")


### PR DESCRIPTION
## 📌 관련 이슈
- close #118 

## 📝 변경 사항
### AS-IS
- 프로필 생성 후 발급되는 토큰으로 로그아웃 시도 시 에러 발생
- 프로필 생성 후 발급되는 RefreshToken이 DB에 정상적으로 업데이트가 되지 않음

### TO-BE
- 프로필 생성 후 발급되는 RefreshToken이 DB에 정상적으로 업데이트되도록 수정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.