### PR TITLE
[fix] 이메일 인증 코드 발송  / 비밀번호 재설정 도메인 변경

### DIFF
--- a/src/main/java/com/momo/auth/join/controller/JoinController.java
+++ b/src/main/java/com/momo/auth/join/controller/JoinController.java
@@ -24,7 +24,7 @@ public class JoinController {
   @PostMapping("/api/v1/users/signup")
   public ResponseEntity<String> join(@RequestBody JoinDTO joinDto) throws MessagingException {
     joinService.joinProcess(joinDto);
-    return ResponseEntity.ok("회원가입이 완료되었습니다. 이메일 인증을 마쳐주세요.");
+    return ResponseEntity.ok("입력하신 이메일로 인증 요청이 전송되었습니다. 메일을 확인해주세요.");
   }
 
 }

--- a/src/main/java/com/momo/auth/join/controller/VerificationController.java
+++ b/src/main/java/com/momo/auth/join/controller/VerificationController.java
@@ -1,25 +1,27 @@
 package com.momo.auth.join.controller;
 
+import com.momo.auth.join.service.JoinService;
 import com.momo.auth.join.service.VerificationService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping
+@RequiredArgsConstructor
 public class VerificationController {
 
   private final VerificationService verificationService;
+  private final JoinService joinService;
 
-  public VerificationController(VerificationService verificationService) {
-    this.verificationService = verificationService;
-  }
 
-  @GetMapping("/api/v1/users/signup/verify")
-  public ResponseEntity<String> verifyUser(@RequestParam("token") String token) {
-    verificationService.verifyUser(token); // 서비스 호출
-    return ResponseEntity.ok("이메일 인증이 완료되었습니다!");
+  @PostMapping("/api/v1/users/signup/verify")
+  public ResponseEntity<String> verifyCode(@RequestParam String code) {
+    joinService.verifyCode(code);
+    return ResponseEntity.ok("이메일 인증이 완료되었습니다.");
   }
 }

--- a/src/main/java/com/momo/common/exception/ErrorCode.java
+++ b/src/main/java/com/momo/common/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
   PROFILE_NOT_FOUND("프로필을 찾을 수 없습니다.", 400),
   KAKAO_UNLINK_FAILED("카카오 계정 연동해제를 실패했습니다.", 400),
   OPTIMISTIC_LOCKING_FAILURE(
-      "이미 다른 처리가 진행되었습니다. 새로고침 후 다시 시도해 주세요.", 400);
+      "이미 다른 처리가 진행되었습니다. 새로고침 후 다시 시도해 주세요.", 400),
+  INVALID_VERIFICATION_CODE("유효하지않은 토큰입니다.",400);
 
   private final String message;
   private final int status;

--- a/src/main/java/com/momo/user/service/EmailService.java
+++ b/src/main/java/com/momo/user/service/EmailService.java
@@ -17,18 +17,17 @@ public class EmailService {
     this.mailSender = mailSender;
   }
 
-  public void sendVerificationEmail(String recipientEmail, String token) throws MessagingException {
-    String subject = "이메일 인증 요청";
-    String verificationUrl = "http://localhost:8080/users/verify?token=" + token;
+  public void sendVerificationCodeEmail(String recipientEmail, String code) throws MessagingException {
+    String subject = "이메일 인증 코드";
     String message = "<h1>이메일 인증</h1>" +
-        "<p>아래 링크를 클릭하여 이메일 인증을 완료해주세요:</p>" +
-        "<a href=\"" + verificationUrl + "\">이메일 인증하기</a>";
+        "<p>아래 인증 코드를 입력하여 이메일 인증을 완료해주세요:</p>" +
+        "<h2>" + code + "</h2>";
 
     MimeMessage mimeMessage = mailSender.createMimeMessage();
     MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
     helper.setTo(recipientEmail);
     helper.setSubject(subject);
-    helper.setText(message, true); // HTML 형식 허용
+    helper.setText(message, true);
 
     mailSender.send(mimeMessage);
   }
@@ -36,7 +35,7 @@ public class EmailService {
   public void sendPasswordResetEmail(String recipientEmail, String token) {
     try {
       String subject = "비밀번호 재설정 요청";
-      String resetUrl = "http://localhost:8080/api/v1/users/reset-password?token=" + token;
+      String resetUrl = "http://localhost:5173/reset-password/callback?token=" + token;
       String message = "<h1>비밀번호 재설정</h1>" +
           "<p>아래 링크를 클릭하여 비밀번호를 재설정해주세요:</p>" +
           "<a href=\"" + resetUrl + "\">비밀번호 재설정하기</a>";


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 이메일 인증 단계에서 메일로 링크가 전송되고 있음.
- 비밀번호 재설정위해 필요한 코드를 포함 링크가 백엔드 API로 호출되고 있음.

### TO-BE
- 이메일로 링크가 아닌 랜덤 코드가 바로 전송될 수 있도록 수정
- 비밀번호 재설정 링크를 프론트엔드에서 처리할 수 있는 도메인 URL로 변경  

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
- 이메일 인증 코드 발송 
<img width="381" alt="스크린샷 2025-01-17 오전 3 34 00" src="https://github.com/user-attachments/assets/5ac0695e-07c6-4f77-8628-fc8d5ef6dd50" />



## ✅ 체크리스트
- [ ] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
확인부탁드립니다.