### PR TITLE
[fix] 프로필 생성 전 프로필 조회시 반환하는 오류 번호 수정

### DIFF
--- a/src/main/java/com/momo/common/exception/ErrorCode.java
+++ b/src/main/java/com/momo/common/exception/ErrorCode.java
@@ -4,7 +4,7 @@ public enum ErrorCode {
   INVALID_VERIFICATION_TOKEN("유효하지 않은 인증 토큰입니다.", 400),
   VALIDATION_ERROR("잘못된 요청입니다", 400),
   DUPLICATE_ERROR("이미 사용 중인 값입니다", 409),
-  INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다", 500),
+  INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다", 403),
   USER_NOT_FOUND("사용자를 찾을 수 없습니다", 404),
   NOT_EXISTS_PROFILE("프로필 생성을 완료해 주세요.", 403),
   INVALID_KAKAO_RESPONSE("잘못된 Kakao API 응답입니다.", 400),


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 프로필 생성 전 프로필 조회시 500번 오류 반환
- 프론트 측에서 프로필 생성 검증 오류 분리를 위해서는 403 오류를 필요로 하는데 계속 500번 오류를 반환하고있음.
- 임시방편으로 해결

### TO-BE
- 500에서 403으로 오류 번호(만) 수정
- 오류 반환 내용에는 수정 없음

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷

- 오류번호 반환 확인
<img width="735" alt="일반회원" src="https://github.com/user-attachments/assets/d91eb2ce-d9aa-4dcd-bb57-b4462b07b442" />
<img width="735" alt="카카오회원" src="https://github.com/user-attachments/assets/20a07856-23d5-4824-8258-c63e22ab623b" />


## ✅ 체크리스트
- [ ] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
현재 프론트 분들 작업을 위해 임시방편으로 오류 번호를 변경해두었습니다.
이대로 진행해도 문제가 없을지 확인부탁드립니다.
