### PR TITLE
[Feature] 만료된 모임 자동 삭제 기능 구현

### DIFF
--- a/src/main/java/com/momo/MomoApplication.java
+++ b/src/main/java/com/momo/MomoApplication.java
@@ -3,7 +3,9 @@ package com.momo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class MomoApplication {

--- a/src/main/java/com/momo/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/momo/chat/repository/ChatRoomRepository.java
@@ -5,6 +5,9 @@ import com.momo.user.entity.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +18,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   List<ChatRoom> findAllByReaderContains(User user);
 
   Optional<ChatRoom> findByMeeting_Id(Long id);
+
+  @Modifying
+  @Query("DELETE FROM ChatRoom cr WHERE cr.meeting.id IN :meetingIds")
+  int deleteAllByMeetingIds(@Param("meetingIds") List<Long> meetingIds);
 }

--- a/src/main/java/com/momo/meeting/projection/ExpiredMeetingProjection.java
+++ b/src/main/java/com/momo/meeting/projection/ExpiredMeetingProjection.java
@@ -1,0 +1,12 @@
+package com.momo.meeting.projection;
+
+import com.momo.user.entity.User;
+
+public interface ExpiredMeetingProjection {
+
+  Long getMeetingId();
+
+  String getTitle();
+
+  User getAuthor();
+}

--- a/src/main/java/com/momo/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/momo/meeting/repository/MeetingRepository.java
@@ -1,11 +1,14 @@
 package com.momo.meeting.repository;
 
+import com.momo.meeting.constant.MeetingStatus;
 import com.momo.meeting.entity.Meeting;
 import com.momo.meeting.projection.CreatedMeetingProjection;
+import com.momo.meeting.projection.ExpiredMeetingProjection;
 import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -135,4 +138,20 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
       @Param("lastId") Long lastId,
       @Param("pageSize") int pageSize
   );
+
+  @Query("SELECT DISTINCT "
+      + "m.id as meetingId, "
+      + "m.title as title, "
+      + "m.user as author " +
+      "FROM Meeting m " +
+      "WHERE m.meetingStatus = :meetingStatus " +
+      "AND m.meetingDateTime < :now")
+  List<ExpiredMeetingProjection> findExpiredMeetings(
+      @Param("meetingStatus") MeetingStatus meetingStatus,
+      @Param("now") LocalDateTime now
+  );
+
+  @Modifying
+  @Query("DELETE FROM Meeting m WHERE m.id IN :meetingIds")
+  int deleteAllByMeetingIds(@Param("meetingIds") List<Long> meetingIds);
 }

--- a/src/main/java/com/momo/notification/constant/NotificationType.java
+++ b/src/main/java/com/momo/notification/constant/NotificationType.java
@@ -12,6 +12,9 @@ public enum NotificationType {
 
   PARTICIPANT_LEFT("참가자 탈퇴", NotificationCategory.MEETING),
 
+  MEETING_EXPIRED(
+      "모임이 모임 시간이 만료되어 자동으로 삭제되었습니다.", NotificationCategory.MEETING),
+
   // 모임 관련 (참가자)
   PARTICIPANT_APPROVED("모임에 참여가 승인되었습니다.", NotificationCategory.MEETING),
 

--- a/src/main/java/com/momo/notification/service/NotificationService.java
+++ b/src/main/java/com/momo/notification/service/NotificationService.java
@@ -45,7 +45,8 @@ public class NotificationService {
   }
 
   /**
-   * 새로운 알림을 생성하고 실시간으로 전송하는 메서드. 알림을 보내야 하는 서비스 쪽에서 호출하여 사용.
+   * 새로운 알림을 생성하고 실시간으로 전송하는 메서드.
+   * 알림을 보내야 하는 서비스 쪽에서 호출하여 사용.
    *
    * @param user             알림 수신자
    * @param notificationType 알림 타입
@@ -55,7 +56,7 @@ public class NotificationService {
     Notification notification = createNotification(user, content, notificationType);
     notificationRepository.save(notification);
 
-    trySendNotification(user, notificationType, notification); // 실시간 알림 전송 시도
+    trySendNotification(user.getId(), notificationType, notification); // 실시간 알림 전송 시도
     boolean hasNotifications = notificationRepository.existsByUser_Id(user.getId());
     tryNotifyNotificationStatus(user.getId(), hasNotifications);
   }
@@ -83,9 +84,9 @@ public class NotificationService {
   }
 
   private void trySendNotification(
-      User user, NotificationType notificationType, Notification notification
+      Long userId, NotificationType notificationType, Notification notification
   ) {
-    sseEmitterManager.get(user.getId())
+    sseEmitterManager.get(userId)
         .ifPresent(sseEmitter -> {
           try {
             sseEmitter.send(SseEmitter.event()
@@ -93,7 +94,7 @@ public class NotificationService {
                 .data(notification.getContent())); // 알림 데이터 전송
           } catch (IOException e) {
             // 전송 실패 시 연결 제거
-            sseEmitterManager.remove(user.getId());
+            sseEmitterManager.remove(userId);
           }
         });
   }

--- a/src/main/java/com/momo/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/momo/participation/repository/ParticipationRepository.java
@@ -1,10 +1,13 @@
 package com.momo.participation.repository;
 
 import com.momo.meeting.projection.MeetingParticipantProjection;
+import com.momo.participation.constant.ParticipationStatus;
 import com.momo.participation.entity.Participation;
 import com.momo.participation.projection.AppliedMeetingProjection;
+import com.momo.user.entity.User;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -65,4 +68,16 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
   List<MeetingParticipantProjection> findMeetingParticipantsByMeeting_Id(
       @Param("meetingId") Long meetingId
   );
+
+  @Query("SELECT p.user FROM Participation p " +
+      "WHERE p.meeting.id IN :meetingIds " +
+      "  AND p.participationStatus = :participationStatus")
+  List<User> findParticipantsByMeetingIds(
+      @Param("meetingIds") List<Long> meetingIds,
+      @Param("participationStatus") ParticipationStatus participationStatus
+  );
+
+  @Modifying
+  @Query("DELETE FROM Participation p WHERE p.meeting.id IN :meetingIds")
+  int deleteAllByMeetingIds(@Param("meetingIds") List<Long> meetingIds);
 }

--- a/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
@@ -8,10 +8,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.momo.chat.entity.ChatRoom;
+import com.momo.chat.repository.ChatRoomRepository;
 import com.momo.chat.service.ChatRoomService;
 import com.momo.meeting.constant.FoodCategory;
 import com.momo.meeting.constant.MeetingStatus;
@@ -27,9 +28,12 @@ import com.momo.meeting.entity.Meeting;
 import com.momo.meeting.exception.MeetingErrorCode;
 import com.momo.meeting.exception.MeetingException;
 import com.momo.meeting.projection.CreatedMeetingProjection;
+import com.momo.meeting.projection.ExpiredMeetingProjection;
 import com.momo.meeting.projection.MeetingParticipantProjection;
 import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
 import com.momo.meeting.repository.MeetingRepository;
+import com.momo.notification.constant.NotificationType;
+import com.momo.notification.service.NotificationService;
 import com.momo.participation.constant.ParticipationStatus;
 import com.momo.participation.repository.ParticipationRepository;
 import com.momo.user.entity.User;
@@ -37,6 +41,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -45,7 +50,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class MeetingServiceTest {
@@ -57,7 +65,16 @@ class MeetingServiceTest {
   private ParticipationRepository participationRepository;
 
   @Mock
+  private ChatRoomRepository chatRoomRepository;
+
+  @Mock
   private ChatRoomService chatRoomService;
+
+  @Mock
+  private TransactionTemplate transactionTemplate;
+
+  @Mock
+  private NotificationService notificationService;
 
   @InjectMocks
   private MeetingService meetingService;
@@ -199,80 +216,6 @@ class MeetingServiceTest {
     verify(meetingRepository).countByUser_IdAndCreatedAtBetween(eq(user.getId()), any(), any());
   }
 
-  private static MeetingsRequest createMeetingsRequest(
-      Double userLatitude,
-      Double userLongitude,
-      Long lastId,
-      Double lastDistance,
-      LocalDateTime lastMeetingDateTime
-  ) {
-    return MeetingsRequest.createRequest(
-        userLatitude,
-        userLongitude,
-        null,
-        null,
-        null,
-        TEST_PAGE_SIZE
-    );
-  }
-
-  private List<MeetingToMeetingDtoProjection> createMockProjections() {
-    List<MeetingToMeetingDtoProjection> projections = new ArrayList<>();
-    // 모의 데이터 생성 로직
-    for (int i = 1; i <= TEST_PAGE_SIZE + 1; i++) { // pageSize + 1
-      createMockProjection(projections, i);
-    }
-    return projections;
-  }
-
-  private static void createMockProjection(List<MeetingToMeetingDtoProjection> projections, int i) {
-    MeetingToMeetingDtoProjection projection = mock(MeetingToMeetingDtoProjection.class);
-    when(projection.getId()).thenReturn((long) i);
-    when(projection.getAuthorId()).thenReturn((long) i * 100);
-    when(projection.getTitle()).thenReturn("title" + i);
-    when(projection.getLocationId()).thenReturn((long) i);
-    when(projection.getLatitude()).thenReturn((double) i);
-    when(projection.getLongitude()).thenReturn((double) i);
-    when(projection.getAddress()).thenReturn("address" + i);
-    when(projection.getMeetingDateTime())
-        .thenReturn(LocalDateTime.now().plusDays(1 + i).truncatedTo(ChronoUnit.MINUTES));
-    when(projection.getMaxCount()).thenReturn(2 + i);
-    when(projection.getApprovedCount()).thenReturn(1 + i);
-    when(projection.getCategory()).thenReturn("KOREAN,JAPANESE");
-    when(projection.getThumbnailUrl()).thenReturn("test-url" + i + ".jpg");
-    projections.add(projection);
-  }
-
-  private static void verifyMeetingDtos(List<MeetingDto> meetingDtos) {
-    for (int i = 1; i < TEST_PAGE_SIZE + 1; i++) {
-      verifyMeetingDto(meetingDtos, i);
-    }
-  }
-
-  private static void verifyMeetingDto(List<MeetingDto> meetingDtos, int i) {
-    MeetingDto meetingDto = meetingDtos.get(i - 1);
-    assertEquals(i, meetingDto.getId());
-    assertEquals(i * 100L, meetingDto.getAuthorId());
-    assertEquals("title" + i, meetingDto.getTitle());
-    assertEquals(i, meetingDto.getLocationId());
-    assertEquals(i, meetingDto.getLatitude());
-    assertEquals(i, meetingDto.getLongitude());
-    assertEquals("address" + i, meetingDto.getAddress());
-    assertEquals(LocalDateTime.now().plusDays(1 + i).truncatedTo(ChronoUnit.MINUTES),
-        meetingDto.getMeetingDateTime());
-    assertEquals(2 + i, meetingDto.getMaxCount());
-    assertEquals(1 + i, meetingDto.getApprovedCount());
-    assertEquals(Set.of("한식", "일식"), meetingDto.getCategory());
-    assertEquals("test-url" + i + ".jpg", meetingDto.getThumbnailUrl());
-  }
-
-  private static void verifyCursor(MeetingsResponse response) {
-    List<MeetingDto> meetingDtos = response.getMeetings();
-    MeetingDto meetingDto = meetingDtos.get(meetingDtos.size() - 1);
-    MeetingCursor cursor = response.getCursor();
-    assertEquals(cursor.getId(), meetingDto.getId());
-  }
-
   @Test
   @DisplayName("모임 수정 - 성공")
   void updateMeeting_Success() {
@@ -362,10 +305,228 @@ class MeetingServiceTest {
     verify(meetingRepository).findById(user.getId());
   }
 
+  @Test
+  @DisplayName("작성한 모임 목록 조회 - 성공")
+  void getCreatedMeetings_Success() {
+    // given
+    Long userId = 1L;
+    Long lastId = 0L;
+
+    List<CreatedMeetingProjection> projections = createdMeetingsMockProjections();
+
+    given(meetingRepository.findAllByUser_IdOrderByCreatedAtAsc(
+        userId, lastId, TEST_PAGE_SIZE + 1)).willReturn(projections);
+
+    // when
+    CreatedMeetingsResponse response =
+        meetingService.getCreatedMeetings(userId, lastId, TEST_PAGE_SIZE);
+
+    // then
+    List<CreatedMeetingDto> createdMeetingDtos = response.getCreatedMeetingDtos();
+    assertThat(createdMeetingDtos).hasSize(TEST_PAGE_SIZE);
+
+    assertThatCreatedMeetingDtos(createdMeetingDtos);
+    verify(meetingRepository)
+        .findAllByUser_IdOrderByCreatedAtAsc(userId, lastId, TEST_PAGE_SIZE + 1);
+  }
+
+  @Test
+  @DisplayName("모임 신청자 목록 조회 - 성공")
+  void getParticipants_Success() {
+    // given
+    User user = createUser();
+    MeetingCreateRequest request = createMeetingRequest();
+    Meeting meeting = createMeeting(user, request);
+    List<MeetingParticipantProjection> projections = createMockParticipantProjections();
+
+    given(meetingRepository.findById(meeting.getId())).willReturn(Optional.of(meeting));
+    given(participationRepository.findMeetingParticipantsByMeeting_Id(meeting.getId()))
+        .willReturn(projections);
+
+    // when
+    List<MeetingParticipantProjection> participants =
+        meetingService.getParticipants(user.getId(), meeting.getId());
+
+    // then
+    assertThat(participants).hasSize(TEST_PAGE_SIZE + 1);
+
+    assertThatMeetingParticipants(participants);
+    verify(meetingRepository).findById(meeting.getId());
+    verify(participationRepository).findMeetingParticipantsByMeeting_Id(meeting.getId());
+  }
+
+  @Test
+  @DisplayName("만료된 모임 삭제 - 성공")
+  void deleteExpiredMeetingsAndNotify_Success() {
+
+    class ExpiredMeetingImpl implements ExpiredMeetingProjection {
+
+      Long meetingId;
+      String title;
+      User author;
+
+      ExpiredMeetingImpl(Meeting meeting) {
+        this.meetingId = meeting.getId();
+        this.title = meeting.getTitle();
+        this.author = meeting.getUser();
+      }
+
+      @Override
+      public Long getMeetingId() {
+        return meetingId;
+      }
+
+      @Override
+      public String getTitle() {
+        return title;
+      }
+
+      @Override
+      public User getAuthor() {
+        return author;
+      }
+    }
+    // given
+    User author = createAuthor(2L, "author-test.com");
+    MeetingCreateRequest request = createMeetingRequest();
+    Meeting meeting = createMeeting(author, request);
+
+    MockitoAnnotations.openMocks(this);
+    ExpiredMeetingProjection expiredMeeting = new ExpiredMeetingImpl(meeting);
+    List<ExpiredMeetingProjection> expiredMeetings = new ArrayList<>(List.of(expiredMeeting));
+
+    when(meetingRepository.findExpiredMeetings(any(MeetingStatus.class), any(LocalDateTime.class)))
+        .thenReturn(expiredMeetings);
+
+    // transactionTemplate이 실행될 때 콜백 동작 설정
+    when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+      TransactionCallback<?> callback = invocation.getArgument(0);
+      return callback.doInTransaction(null);
+    });
+
+    when(chatRoomRepository.deleteAllByMeetingIds(List.of(meeting.getId()))).thenReturn(1);
+    when(participationRepository.deleteAllByMeetingIds(List.of(meeting.getId()))).thenReturn(1);
+    when(meetingRepository.deleteAllByMeetingIds(List.of(meeting.getId()))).thenReturn(1);
+
+    // when
+    meetingService.deleteExpiredMeetingsAndNotify();
+
+    // then
+    verify(notificationService).sendNotification(
+        author,
+        meeting.getTitle() + NotificationType.MEETING_EXPIRED.getDescription(),
+        NotificationType.MEETING_EXPIRED
+    );
+    verify(chatRoomRepository).deleteAllByMeetingIds(List.of(1L));
+    verify(participationRepository).deleteAllByMeetingIds(List.of(1L));
+    verify(meetingRepository).deleteAllByMeetingIds(List.of(1L));
+  }
+
+  @Test
+  @DisplayName("만료된 모임 삭제 - 만료된 모임이 없는 경우")
+  void deleteExpiredMeetingsAndNotify_NoExpiredMeetings() {
+    // given
+    when(meetingRepository.findExpiredMeetings(any(MeetingStatus.class), any(LocalDateTime.class)))
+        .thenReturn(Collections.emptyList());
+    // when
+    meetingService.deleteExpiredMeetingsAndNotify();
+
+    // then
+    // 만료된 모임이 없으므로 Repository 메서드가 호출되지 않음을 검증
+    verify(chatRoomRepository, never()).deleteAllByMeetingIds(any());
+    verify(participationRepository, never()).deleteAllByMeetingIds(any());
+    verify(meetingRepository, never()).deleteAllByMeetingIds(any());
+  }
+
+  private static MeetingsRequest createMeetingsRequest(
+      Double userLatitude,
+      Double userLongitude,
+      Long lastId,
+      Double lastDistance,
+      LocalDateTime lastMeetingDateTime
+  ) {
+    return MeetingsRequest.createRequest(
+        userLatitude,
+        userLongitude,
+        null,
+        null,
+        null,
+        TEST_PAGE_SIZE
+    );
+  }
+
+  private List<MeetingToMeetingDtoProjection> createMockProjections() {
+    List<MeetingToMeetingDtoProjection> projections = new ArrayList<>();
+    // 모의 데이터 생성 로직
+    for (int i = 1; i <= TEST_PAGE_SIZE + 1; i++) { // pageSize + 1
+      createMockProjection(projections, i);
+    }
+    return projections;
+  }
+
+  private static void createMockProjection(List<MeetingToMeetingDtoProjection> projections, int i) {
+    MeetingToMeetingDtoProjection projection = mock(MeetingToMeetingDtoProjection.class);
+    when(projection.getId()).thenReturn((long) i);
+    when(projection.getAuthorId()).thenReturn((long) i * 100);
+    when(projection.getTitle()).thenReturn("title" + i);
+    when(projection.getLocationId()).thenReturn((long) i);
+    when(projection.getLatitude()).thenReturn((double) i);
+    when(projection.getLongitude()).thenReturn((double) i);
+    when(projection.getAddress()).thenReturn("address" + i);
+    when(projection.getMeetingDateTime())
+        .thenReturn(LocalDateTime.now().plusDays(1 + i).truncatedTo(ChronoUnit.MINUTES));
+    when(projection.getMaxCount()).thenReturn(2 + i);
+    when(projection.getApprovedCount()).thenReturn(1 + i);
+    when(projection.getCategory()).thenReturn("KOREAN,JAPANESE");
+    when(projection.getThumbnailUrl()).thenReturn("test-url" + i + ".jpg");
+    projections.add(projection);
+  }
+
+  private static void verifyMeetingDtos(List<MeetingDto> meetingDtos) {
+    for (int i = 1; i < TEST_PAGE_SIZE + 1; i++) {
+      verifyMeetingDto(meetingDtos, i);
+    }
+  }
+
+  private static void verifyMeetingDto(List<MeetingDto> meetingDtos, int i) {
+    MeetingDto meetingDto = meetingDtos.get(i - 1);
+    assertEquals(i, meetingDto.getId());
+    assertEquals(i * 100L, meetingDto.getAuthorId());
+    assertEquals("title" + i, meetingDto.getTitle());
+    assertEquals(i, meetingDto.getLocationId());
+    assertEquals(i, meetingDto.getLatitude());
+    assertEquals(i, meetingDto.getLongitude());
+    assertEquals("address" + i, meetingDto.getAddress());
+    assertEquals(LocalDateTime.now().plusDays(1 + i).truncatedTo(ChronoUnit.MINUTES),
+        meetingDto.getMeetingDateTime());
+    assertEquals(2 + i, meetingDto.getMaxCount());
+    assertEquals(1 + i, meetingDto.getApprovedCount());
+    assertEquals(Set.of("한식", "일식"), meetingDto.getCategory());
+    assertEquals("test-url" + i + ".jpg", meetingDto.getThumbnailUrl());
+  }
+
+  private static void verifyCursor(MeetingsResponse response) {
+    List<MeetingDto> meetingDtos = response.getMeetings();
+    MeetingDto meetingDto = meetingDtos.get(meetingDtos.size() - 1);
+    MeetingCursor cursor = response.getCursor();
+    assertEquals(cursor.getId(), meetingDto.getId());
+  }
+
   private static User createUser() {
     return User.builder()
         .id(1L)
         .email("test@gmail.com")
+        .password("testapssword")
+        .phone("01012345678")
+        .enabled(true)
+        .verificationToken("asdasdsad")
+        .build();
+  }
+
+  private static User createAuthor(Long userId, String email) {
+    return User.builder()
+        .id(userId)
+        .email(email)
         .password("testapssword")
         .phone("01012345678")
         .enabled(true)
@@ -422,31 +583,6 @@ class MeetingServiceTest {
         .build();
   }
 
-  @Test
-  @DisplayName("작성한 모임 목록 조회 - 성공")
-  void getCreatedMeetings_Success() {
-    // given
-    Long userId = 1L;
-    Long lastId = 0L;
-
-    List<CreatedMeetingProjection> projections = createdMeetingsMockProjections();
-
-    given(meetingRepository.findAllByUser_IdOrderByCreatedAtAsc(
-        userId, lastId, TEST_PAGE_SIZE + 1)).willReturn(projections);
-
-    // when
-    CreatedMeetingsResponse response =
-        meetingService.getCreatedMeetings(userId, lastId, TEST_PAGE_SIZE);
-
-    // then
-    List<CreatedMeetingDto> createdMeetingDtos = response.getCreatedMeetingDtos();
-    assertThat(createdMeetingDtos).hasSize(TEST_PAGE_SIZE);
-
-    assertThatCreatedMeetingDtos(createdMeetingDtos);
-    verify(meetingRepository)
-        .findAllByUser_IdOrderByCreatedAtAsc(userId, lastId, TEST_PAGE_SIZE + 1);
-  }
-
   private List<CreatedMeetingProjection> createdMeetingsMockProjections() {
     List<CreatedMeetingProjection> projections = new ArrayList<>();
 
@@ -501,31 +637,6 @@ class MeetingServiceTest {
     assertThat(createdMeetingDto.get(i).getContent()).isEqualTo("Test Content " + i);
     assertThat(createdMeetingDto.get(i).getThumbnailUrl())
         .isEqualTo("test_" + i + "_thumbnail_url.jpg");
-  }
-
-  @Test
-  @DisplayName("모임 신청자 목록 조회 - 성공")
-  void getParticipants_Success() {
-    // given
-    User user = createUser();
-    MeetingCreateRequest request = createMeetingRequest();
-    Meeting meeting = createMeeting(user, request);
-    List<MeetingParticipantProjection> projections = createMockParticipantProjections();
-
-    given(meetingRepository.findById(meeting.getId())).willReturn(Optional.of(meeting));
-    given(participationRepository.findMeetingParticipantsByMeeting_Id(meeting.getId()))
-        .willReturn(projections);
-
-    // when
-    List<MeetingParticipantProjection> participants =
-        meetingService.getParticipants(user.getId(), meeting.getId());
-
-    // then
-    assertThat(participants).hasSize(TEST_PAGE_SIZE + 1);
-
-    assertThatMeetingParticipants(participants);
-    verify(meetingRepository).findById(meeting.getId());
-    verify(participationRepository).findMeetingParticipantsByMeeting_Id(meeting.getId());
   }
 
   private static List<MeetingParticipantProjection> createMockParticipantProjections() {


### PR DESCRIPTION
## 📌 관련 이슈
- close #133 

## 📝 변경 사항
### AS-IS
- 모임 상태가 'RECRUITING'이며 모임 날짜가 지난 모임은 사실상 의미가 없는 모임인데 유지됨

### TO-BE
- 모임 상태가 'RECRUITING'이며 모임 날짜가 지난 모임을 자동으로 삭제하는 기능 구현
- 5분마다 실행되도록 스케줄링으로 구현
- 만료된 모임, 해당 모임의 승인된 참여 신청, 해당 모임의 채팅방 모두 삭제
- 삭제된 모임과 참여자들에게 알림 전송
- 만료된 모임이 있을 때 테스트 코드 구현
- 만료된 모임이 없을 때 테스트 코드 구현

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.