### PR TITLE
[Rename] 썸네일 필드의 이름을 thumbnailUrl에서 thumbnail로 변경

### DIFF
--- a/src/main/java/com/momo/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/momo/chat/dto/ChatRoomDto.java
@@ -63,7 +63,7 @@ public class ChatRoomDto {
     return new ChatRoomDto(
         chatRoom.getId(),
         chatRoom.getMeeting().getId(),
-        chatRoom.getMeeting().getThumbnailUrl(),
+        chatRoom.getMeeting().getThumbnail(),
         chatRoom.getMeeting().getTitle(),
         lastMessage,
         chatRoom.getHost().getId(),

--- a/src/main/java/com/momo/chat/service/ChatRoomService.java
+++ b/src/main/java/com/momo/chat/service/ChatRoomService.java
@@ -211,7 +211,7 @@ public class ChatRoomService {
           return new ChatRoomDto(
               chatRoom.getId(),
               chatRoom.getMeeting().getId(),
-              chatRoom.getMeeting().getThumbnailUrl(),
+              chatRoom.getMeeting().getThumbnail(),
               chatRoom.getMeeting().getTitle(),
               lastMessage,
               chatRoom.getHost().getId(),

--- a/src/main/java/com/momo/meeting/dto/MeetingDto.java
+++ b/src/main/java/com/momo/meeting/dto/MeetingDto.java
@@ -30,7 +30,7 @@ public class MeetingDto {
   private Integer approvedCount;
   private Set<String> category;
   private String content;
-  private String thumbnailUrl;
+  private String thumbnail;
   private Double distance;
 
   public static List<MeetingDto> convertToMeetingDtos(
@@ -59,7 +59,7 @@ public class MeetingDto {
         .approvedCount(meetingProjection.getApprovedCount())
         .category(foodCategories)
         .content(meetingProjection.getContent())
-        .thumbnailUrl(meetingProjection.getThumbnailUrl())
+        .thumbnail(meetingProjection.getThumbnailUrl())
         .distance(meetingProjection.getDistance())
         .build();
   }

--- a/src/main/java/com/momo/meeting/dto/create/MeetingCreateRequest.java
+++ b/src/main/java/com/momo/meeting/dto/create/MeetingCreateRequest.java
@@ -52,7 +52,7 @@ public class MeetingCreateRequest {
   @Size(min = 1, max = 600, message = "내용은 600자 이하로 입력해주세요.")
   private String content;
 
-  private String thumbnailUrl;
+  private String thumbnail;
 
   public Meeting toEntity(MeetingCreateRequest request, User user) {
     return Meeting.builder()
@@ -67,7 +67,7 @@ public class MeetingCreateRequest {
         .maxCount(request.getMaxCount())
         .category(request.getCategory())
         .content(request.getContent())
-        .thumbnailUrl(request.getThumbnailUrl())
+        .thumbnail(request.getThumbnail())
         .meetingStatus(MeetingStatus.RECRUITING)
         .build();
   }

--- a/src/main/java/com/momo/meeting/dto/create/MeetingCreateResponse.java
+++ b/src/main/java/com/momo/meeting/dto/create/MeetingCreateResponse.java
@@ -23,7 +23,7 @@ public class MeetingCreateResponse {
   private Integer approvedCount;
   private Set<FoodCategory> category;
   private String content;
-  private String thumbnailUrl;
+  private String thumbnail;
   private MeetingStatus meetingStatus;
 
   public static MeetingCreateResponse from(Meeting meeting) {
@@ -39,7 +39,7 @@ public class MeetingCreateResponse {
         .approvedCount(meeting.getApprovedCount())
         .category(meeting.getCategory())
         .content(meeting.getContent())
-        .thumbnailUrl(meeting.getThumbnailUrl())
+        .thumbnail(meeting.getThumbnail())
         .meetingStatus(meeting.getMeetingStatus())
         .build();
   }

--- a/src/main/java/com/momo/meeting/dto/createdMeeting/CreatedMeetingDto.java
+++ b/src/main/java/com/momo/meeting/dto/createdMeeting/CreatedMeetingDto.java
@@ -28,7 +28,7 @@ public class CreatedMeetingDto {
   private Integer approvedCount;
   private Set<String> category;
   private String content;
-  private String thumbnailUrl;
+  private String thumbnail;
 
   public static List<CreatedMeetingDto> convertToCreatedMeetingDto(
       List<CreatedMeetingProjection> createdMeetingProjections
@@ -61,7 +61,7 @@ public class CreatedMeetingDto {
         .approvedCount(createdMeetingProjection.getApprovedCount())
         .category(foodCategories)
         .content(createdMeetingProjection.getContent())
-        .thumbnailUrl(createdMeetingProjection.getThumbnailUrl())
+        .thumbnail(createdMeetingProjection.getThumbnailUrl())
         .build();
   }
 }

--- a/src/main/java/com/momo/meeting/entity/Meeting.java
+++ b/src/main/java/com/momo/meeting/entity/Meeting.java
@@ -75,7 +75,7 @@ public class Meeting extends BaseEntity {
   @Column(nullable = false, length = 600)
   private String content;
 
-  private String thumbnailUrl;
+  private String thumbnail;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
@@ -90,7 +90,7 @@ public class Meeting extends BaseEntity {
     this.meetingDateTime = request.getMeetingDateTime();
     this.maxCount = request.getMaxCount();
     this.content = request.getContent();
-    this.thumbnailUrl = request.getThumbnailUrl();
+    this.thumbnail = request.getThumbnail();
     this.category = request.getCategory();
   }
 

--- a/src/main/java/com/momo/participation/dto/AppliedMeetingDto.java
+++ b/src/main/java/com/momo/participation/dto/AppliedMeetingDto.java
@@ -29,7 +29,7 @@ public class AppliedMeetingDto {
   private Integer approvedCount;
   private Set<String> category;
   private String content;
-  private String thumbnailUrl;
+  private String thumbnail;
 
   public static List<AppliedMeetingDto> convertToAppliedMeetingDtos(
       List<AppliedMeetingProjection> appliedMeetingProjections
@@ -61,7 +61,7 @@ public class AppliedMeetingDto {
         .approvedCount(appliedMeeting.getApprovedCount())
         .category(foodCategories)
         .content(appliedMeeting.getContent())
-        .thumbnailUrl(appliedMeeting.getThumbnailUrl())
+        .thumbnail(appliedMeeting.getThumbnailUrl())
         .build();
   }
 }

--- a/src/main/java/com/momo/participation/service/ParticipationService.java
+++ b/src/main/java/com/momo/participation/service/ParticipationService.java
@@ -59,7 +59,7 @@ public class ParticipationService {
     Participation participation = updateApproveParticipation(authorId, participationId);
     joinChatRoom(participation.getMeeting(), participation); // 채팅방 입장
 
-    // 참여 신청을 보낸 회원에게 알림 발송 TODO: 대량 요청 테스트 후 비동기 처리 고려
+    // 참여 신청을 보낸 회원에게 알림 발송
     sendNotificationToAppliedUser(participation);
   }
 
@@ -68,7 +68,6 @@ public class ParticipationService {
     sendNotificationToAppliedUser(participation); // 참여 신청을 보낸 회원에게 알림 발송
   }
 
-  // TODO: merge 후 public 메서드가 위로 가도록
   public void deleteParticipation(Long userId, Long participationId) {
     Participation participation = validateForDeleteParticipation(userId, participationId);
     participationRepository.delete(participation);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     name: momo
   profiles:
     active: dev
+    include:
+      - local
 
   jwt:
     secret: vmfhaadadadaddaddadltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalqwerqwerqwer

--- a/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.momo.chat.entity.ChatRoom;
 import com.momo.chat.service.ChatRoomService;
 import com.momo.meeting.constant.FoodCategory;
 import com.momo.meeting.constant.MeetingStatus;
@@ -86,14 +85,14 @@ class MeetingServiceTest {
             "address", "meetingDateTime",
             "maxCount", "approvedCount",
             "category", "content",
-            "thumbnailUrl", "meetingStatus"
+            "thumbnail", "meetingStatus"
         ).containsExactly(
             request.getTitle(), request.getLocationId(),
             request.getLatitude(), request.getLongitude(),
             request.getAddress(), request.getMeetingDateTime(),
             request.getMaxCount(), 1,
             request.getCategory(), request.getContent(),
-            request.getThumbnailUrl(), MeetingStatus.RECRUITING
+            request.getThumbnail(), MeetingStatus.RECRUITING
         );
 
     verify(meetingRepository).countByUser_IdAndCreatedAtBetween(user.getId(), startOfDay, endOfDay);
@@ -263,7 +262,7 @@ class MeetingServiceTest {
     assertEquals(2 + i, meetingDto.getMaxCount());
     assertEquals(1 + i, meetingDto.getApprovedCount());
     assertEquals(Set.of("한식", "일식"), meetingDto.getCategory());
-    assertEquals("test-url" + i + ".jpg", meetingDto.getThumbnailUrl());
+    assertEquals("test-url" + i + ".jpg", meetingDto.getThumbnail());
   }
 
   private static void verifyCursor(MeetingsResponse response) {
@@ -296,7 +295,7 @@ class MeetingServiceTest {
             "longitude", "address",
             "meetingDateTime", "maxCount",
             "approvedCount", "category",
-            "content", "thumbnailUrl",
+            "content", "thumbnail",
             "meetingStatus"
         ).containsExactly(
             1L, updateRequest.getTitle(),
@@ -304,7 +303,7 @@ class MeetingServiceTest {
             updateRequest.getLongitude(), updateRequest.getAddress(),
             updateRequest.getMeetingDateTime(), updateRequest.getMaxCount(),
             1, updateRequest.getCategory(),
-            updateRequest.getContent(), updateRequest.getThumbnailUrl(),
+            updateRequest.getContent(), updateRequest.getThumbnail(),
             MeetingStatus.RECRUITING
         );
 
@@ -387,7 +386,7 @@ class MeetingServiceTest {
         .approvedCount(1)
         .category(request.getCategory())
         .content(request.getContent())
-        .thumbnailUrl(request.getThumbnailUrl())
+        .thumbnail(request.getThumbnail())
         .meetingStatus(MeetingStatus.RECRUITING)
         .build();
   }
@@ -403,7 +402,7 @@ class MeetingServiceTest {
         .maxCount(6)
         .category(Set.of(FoodCategory.KOREAN, FoodCategory.JAPANESE))
         .content("테스트 내용")
-        .thumbnailUrl("test-thumbnail-url.jpg")
+        .thumbnail("test-thumbnail-url.jpg")
         .build();
   }
 
@@ -418,7 +417,7 @@ class MeetingServiceTest {
         .maxCount(5)
         .category(Set.of(FoodCategory.DESSERT))
         .content("업데이트 내용")
-        .thumbnailUrl("")
+        .thumbnail("")
         .build();
   }
 
@@ -499,7 +498,7 @@ class MeetingServiceTest {
     assertThat(createdMeetingDto.get(i).getApprovedCount()).isEqualTo(i + 1);
     assertThat(createdMeetingDto.get(i).getCategory()).isEqualTo(Set.of("한식", "디저트"));
     assertThat(createdMeetingDto.get(i).getContent()).isEqualTo("Test Content " + i);
-    assertThat(createdMeetingDto.get(i).getThumbnailUrl())
+    assertThat(createdMeetingDto.get(i).getThumbnail())
         .isEqualTo("test_" + i + "_thumbnail_url.jpg");
   }
 

--- a/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.momo.chat.entity.ChatRoom;
 import com.momo.chat.service.ChatRoomService;
 import com.momo.meeting.constant.FoodCategory;
 import com.momo.meeting.constant.MeetingStatus;
@@ -93,7 +92,7 @@ class MeetingServiceTest {
             request.getAddress(), request.getMeetingDateTime(),
             request.getMaxCount(), 1,
             request.getCategory(), request.getContent(),
-            request.getThumbnailUrl(), MeetingStatus.RECRUITING
+            request.getThumbnail(), MeetingStatus.RECRUITING
         );
 
     verify(meetingRepository).countByUser_IdAndCreatedAtBetween(user.getId(), startOfDay, endOfDay);
@@ -263,7 +262,7 @@ class MeetingServiceTest {
     assertEquals(2 + i, meetingDto.getMaxCount());
     assertEquals(1 + i, meetingDto.getApprovedCount());
     assertEquals(Set.of("한식", "일식"), meetingDto.getCategory());
-    assertEquals("test-url" + i + ".jpg", meetingDto.getThumbnailUrl());
+    assertEquals("test-url" + i + ".jpg", meetingDto.getThumbnail());
   }
 
   private static void verifyCursor(MeetingsResponse response) {
@@ -304,7 +303,7 @@ class MeetingServiceTest {
             updateRequest.getLongitude(), updateRequest.getAddress(),
             updateRequest.getMeetingDateTime(), updateRequest.getMaxCount(),
             1, updateRequest.getCategory(),
-            updateRequest.getContent(), updateRequest.getThumbnailUrl(),
+            updateRequest.getContent(), updateRequest.getThumbnail(),
             MeetingStatus.RECRUITING
         );
 
@@ -387,7 +386,7 @@ class MeetingServiceTest {
         .approvedCount(1)
         .category(request.getCategory())
         .content(request.getContent())
-        .thumbnailUrl(request.getThumbnailUrl())
+        .thumbnail(request.getThumbnail())
         .meetingStatus(MeetingStatus.RECRUITING)
         .build();
   }
@@ -403,7 +402,7 @@ class MeetingServiceTest {
         .maxCount(6)
         .category(Set.of(FoodCategory.KOREAN, FoodCategory.JAPANESE))
         .content("테스트 내용")
-        .thumbnailUrl("test-thumbnail-url.jpg")
+        .thumbnail("test-thumbnail-url.jpg")
         .build();
   }
 
@@ -418,7 +417,7 @@ class MeetingServiceTest {
         .maxCount(5)
         .category(Set.of(FoodCategory.DESSERT))
         .content("업데이트 내용")
-        .thumbnailUrl("")
+        .thumbnail("")
         .build();
   }
 
@@ -499,7 +498,7 @@ class MeetingServiceTest {
     assertThat(createdMeetingDto.get(i).getApprovedCount()).isEqualTo(i + 1);
     assertThat(createdMeetingDto.get(i).getCategory()).isEqualTo(Set.of("한식", "디저트"));
     assertThat(createdMeetingDto.get(i).getContent()).isEqualTo("Test Content " + i);
-    assertThat(createdMeetingDto.get(i).getThumbnailUrl())
+    assertThat(createdMeetingDto.get(i).getThumbnail())
         .isEqualTo("test_" + i + "_thumbnail_url.jpg");
   }
 

--- a/src/test/java/com/momo/participation/service/ParticipationServiceTest.java
+++ b/src/test/java/com/momo/participation/service/ParticipationServiceTest.java
@@ -327,7 +327,7 @@ class ParticipationServiceTest {
         .latitude(32.123123).longitude(127.123123).address("테스트 주소")
         .meetingDateTime(LocalDateTime.now().plusDays(1)).maxCount(6).approvedCount(1)
         .category(Set.of(FoodCategory.KOREAN, FoodCategory.JAPANESE)).content("테스트 내용")
-        .thumbnailUrl("test-thumbnail-url.jpg").meetingStatus(meetingStatus).build();
+        .thumbnail("test-thumbnail-url.jpg").meetingStatus(meetingStatus).build();
   }
 
   private Participation createParticipation(User user, Meeting meeting, ParticipationStatus status) {
@@ -391,7 +391,7 @@ class ParticipationServiceTest {
     assertThat(appliedMeetings.get(i).getApprovedCount()).isEqualTo(i + 1);
     assertThat(appliedMeetings.get(i).getCategory()).isEqualTo(Set.of("한식", "디저트"));
     assertThat(appliedMeetings.get(i).getContent()).isEqualTo("Test Content " + i);
-    assertThat(appliedMeetings.get(i).getThumbnailUrl())
+    assertThat(appliedMeetings.get(i).getThumbnail())
         .isEqualTo("test_" + i + "_thumbnail_url.jpg");
   }
 }


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 썸네일 필드의 이름이 thumbnailUrl

### TO-BE
- 썸네일 필드의 이름을 thumbnail로 변경

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.