### PR TITLE
[Fix] 알림 관련 버그 수정

### DIFF
--- a/src/main/java/com/momo/meeting/service/MeetingService.java
+++ b/src/main/java/com/momo/meeting/service/MeetingService.java
@@ -217,8 +217,7 @@ public class MeetingService {
       recipients.add(expiredMeeting.getAuthor());  // 주최자 추가
       recipients.addAll(participants);  // 참가자들 추가
 
-      String title = expiredMeeting.getTitle() + NotificationType.MEETING_EXPIRED.getDescription();
-      sendNotificationToExpiredMeetingParticipants(recipients, title);
+      sendNotificationToExpiredMeetingParticipants(recipients, expiredMeeting.getTitle());
     }
   }
 

--- a/src/main/java/com/momo/notification/constant/NotificationType.java
+++ b/src/main/java/com/momo/notification/constant/NotificationType.java
@@ -13,7 +13,7 @@ public enum NotificationType {
   PARTICIPANT_LEFT("참가자 탈퇴", NotificationCategory.MEETING),
 
   MEETING_EXPIRED(
-      "모임이 모임 시간이 만료되어 자동으로 삭제되었습니다.", NotificationCategory.MEETING),
+      "모임 시간이 만료되어 자동으로 삭제되었습니다.", NotificationCategory.MEETING),
 
   // 모임 관련 (참가자)
   PARTICIPANT_APPROVED("모임에 참여가 승인되었습니다.", NotificationCategory.MEETING),

--- a/src/main/java/com/momo/notification/service/NotificationService.java
+++ b/src/main/java/com/momo/notification/service/NotificationService.java
@@ -49,8 +49,8 @@ public class NotificationService {
    * 알림을 보내야 하는 서비스 쪽에서 호출하여 사용.
    *
    * @param user             알림 수신자
-   * @param notificationType 알림 타입
    * @param content          알림 내용
+   * @param notificationType 알림 타입
    */
   public void sendNotification(User user, String content, NotificationType notificationType) {
     Notification notification = createNotification(user, content, notificationType);
@@ -114,8 +114,8 @@ public class NotificationService {
       User user, String content, NotificationType notificationType
   ) {
     return Notification.builder()
-        .content(content)
         .user(user)
+        .content(content)
         .notificationType(notificationType)
         .build();
   }

--- a/src/main/java/com/momo/participation/service/ParticipationService.java
+++ b/src/main/java/com/momo/participation/service/ParticipationService.java
@@ -9,6 +9,7 @@ import com.momo.meeting.entity.Meeting;
 import com.momo.meeting.exception.MeetingErrorCode;
 import com.momo.meeting.exception.MeetingException;
 import com.momo.meeting.repository.MeetingRepository;
+import com.momo.notification.constant.NotificationCategory;
 import com.momo.notification.constant.NotificationType;
 import com.momo.notification.service.NotificationService;
 import com.momo.participation.constant.ParticipationStatus;
@@ -60,12 +61,14 @@ public class ParticipationService {
     joinChatRoom(participation.getMeeting(), participation); // 채팅방 입장
 
     // 참여 신청을 보낸 회원에게 알림 발송
-    sendNotificationToAppliedUser(participation);
+    sendNotificationToAppliedUser(participation, NotificationType.PARTICIPANT_APPROVED);
   }
 
   public void rejectParticipation(Long authorId, Long participationId) {
     Participation participation = updateRejectParticipation(authorId, participationId);
-    sendNotificationToAppliedUser(participation); // 참여 신청을 보낸 회원에게 알림 발송
+
+    // 참여 신청을 보낸 회원에게 알림 발송
+    sendNotificationToAppliedUser(participation, NotificationType.PARTICIPANT_REJECTED);
   }
 
   public void deleteParticipation(Long userId, Long participationId) {
@@ -125,12 +128,13 @@ public class ParticipationService {
         .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
   }
 
-  private void sendNotificationToAppliedUser(Participation participation) {
+  private void sendNotificationToAppliedUser(
+      Participation participation, NotificationType notificationType
+  ) {
     notificationService.sendNotification(
         participation.getUser(),
-        participation.getMeeting().getTitle()
-            + NotificationType.PARTICIPANT_APPROVED.getDescription(),
-        NotificationType.PARTICIPANT_APPROVED
+        participation.getMeeting().getTitle() + notificationType.getDescription(),
+        notificationType
     );
   }
 


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 참여 신청 승인 시 'NOTIFICATION_TYPE'이 'PARTICIPANT_APPROVED'로 표시되고 있습니다.
- 모임 자동 삭제 알림 전송 시 'NOTIFICATION_TYPE'의 description이 두 번 표시되고 있습니다.

### TO-BE
- 참여 신청 승인 시 'NOTIFICATION_TYPE'이 'PARTICIPANT_APPROVED'로 표시되던 버그를 'PARTICIPANT_REJECTED'로 표시되도록 수정하였습니다.
- 모임 자동 삭제 알림 전송 시 'NOTIFICATION_TYPE'의 description이 두 번 표시되고 있습니다.

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.