### PR TITLE
[docs] 로그인시 반환 내용 수정

### DIFF
--- a/src/main/java/com/momo/auth/controller/KakaoOAuthController.java
+++ b/src/main/java/com/momo/auth/controller/KakaoOAuthController.java
@@ -52,6 +52,8 @@ public class KakaoOAuthController {
         "accessToken", oauthToken.getAccess_token(),
         "refreshToken", oauthToken.getRefresh_token(),
         "userId", kakaoUser.getId(),
+        "nickname", kakaoUser.getNickname(),
+        "phone", kakaoUser.getPhone(),
         "message", "카카오 계정으로 로그인되었습니다."
     ));
   }

--- a/src/main/java/com/momo/auth/security/LoginFilter.java
+++ b/src/main/java/com/momo/auth/security/LoginFilter.java
@@ -90,8 +90,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
       // Refresh 토큰 저장
       addRefreshToken(user, refreshToken, Duration.ofHours(24).toMillis());
 
+
       // 응답에 토큰 추가
       Map<String, String> tokens = new HashMap<>();
+      tokens.put("userId", String.valueOf(user.getId())); // userId 추가
       tokens.put("accessToken", accessToken);
 
       response.addCookie(createCookie("refresh", refreshToken));

--- a/src/main/java/com/momo/user/service/UserService.java
+++ b/src/main/java/com/momo/user/service/UserService.java
@@ -179,7 +179,8 @@ public class UserService {
 
     User kakaoUser = User.builder()
         .email(email)
-        .nickname(email) // 닉네임 기본값으로 이메일 사용
+        .nickname("")  // 닉네임을 빈 문자열("")로 설정
+        .phone("")  // 전화번호를 빈 문자열("")로 설정
         .password(encryptedPassword)
         .enabled(true)
         .oauthUser(true)


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 일반 로그인시 userId 반환하지 않고 있음.
- 카카오 로그인시 "nickname" 과 "phone"  반환하지 않고 있음.
- 프론트 측 요청으로 반환값 수정 필요

### TO-BE
- 카카오 로그인시 "nickname" 과 "phone" 정보 빈값으로 반환하기
- 일반 로그인시 userId 반환하도록 수정

- 일반 로그인시 userId 반환하도록 수정
## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
<img width="744" alt="스크린샷 2025-01-20 오전 12 16 46" src="https://github.com/user-attachments/assets/7edee9e6-bbb6-4722-ac99-b557fee347ea" />

<img width="744" alt="스크린샷 2025-01-20 오전 12 17 09" src="https://github.com/user-attachments/assets/2fd3d660-258a-487e-9e23-c26a93bcd5ca" />


## ✅ 체크리스트
- [ ] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
확인부탁드립니다.