### PR TITLE
[Feature] 프로필 생성 시 프로필 이미지 없을 경우 null을 반환하도록 수정

### DIFF
--- a/src/main/java/com/momo/profile/service/ProfileImageService.java
+++ b/src/main/java/com/momo/profile/service/ProfileImageService.java
@@ -13,16 +13,13 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class ProfileImageService {
 
-  private static final String DEFAULT_IMAGE_URL =
-      "https://s3-momo-storage.s3.ap-northeast-2.amazonaws.com/default.jpg";
-
   private final ImageStorage imageStorage;
 
   public String getProfileImageUrl(MultipartFile profileImage) {
     return Optional.ofNullable(profileImage)
         .filter(imageFile -> !imageFile.isEmpty())
         .map(this::uploadImage)
-        .orElse(DEFAULT_IMAGE_URL);
+        .orElse(null);
   }
 
   private String uploadImage(MultipartFile profileImage) {

--- a/src/main/java/com/momo/profile/service/ProfileService.java
+++ b/src/main/java/com/momo/profile/service/ProfileService.java
@@ -43,24 +43,24 @@ public class ProfileService {
     validateProfileRequiredValue(gender, birth);
   }
 
-  private void validateHasProfile(Long userId) {
+  private  void validateHasProfile(Long userId) {
     if (profileRepository.existsByUser_Id(userId)) {
       throw new ProfileException(ProfileErrorCode.DUPLICATE_PROFILE);
     }
   }
 
-  private void validateProfileRequiredValue(Gender gender, LocalDate birth) {
+  private static void validateProfileRequiredValue(Gender gender, LocalDate birth) {
     validateGender(gender);
     validateBirth(birth);
   }
 
-  private void validateGender(Gender gender) {
+  private static void validateGender(Gender gender) {
     if (gender == null) {
       throw new ProfileException(ProfileErrorCode.INVALID_GENDER);
     }
   }
 
-  private void validateBirth(LocalDate birth) {
+  private static void validateBirth(LocalDate birth) {
     if (birth == null) {
       throw new ProfileException(ProfileErrorCode.INVALID_BIRTH);
     }

--- a/src/test/java/com/momo/profile/service/ProfileImageServiceTest.java
+++ b/src/test/java/com/momo/profile/service/ProfileImageServiceTest.java
@@ -31,7 +31,7 @@ class ProfileImageServiceTest {
       "https://s3-momo-storage.s3.ap-northeast-2.amazonaws.com/default.jpg";
 
   @Test
-  @DisplayName("이미지가 없을 경우 - 기본 이미지 URL 반환")
+  @DisplayName("이미지가 없을 경우 - null 반환")
   void getProfileImageUrl_WithNullImage_ReturnDefaultImageUrl() {
     // given
     // when
@@ -39,7 +39,7 @@ class ProfileImageServiceTest {
 
     // then
     verifyNoInteractions(imageStorage);
-    assertThat(imageUrl).isEqualTo(DEFAULT_IMAGE_URL);
+    assertThat(imageUrl).isEqualTo(null);
   }
 
   @Test


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 프로필 이미지가 없다면 기본 이미지의 URL 반환

### TO-BE
- 프로필 이미지가 없다면 null 반환

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.