### PR TITLE
[fix] 프로필 이미지 없이 프로필을 생성할 수 있도록 수정

### DIFF
--- a/src/main/java/com/momo/profile/entity/Profile.java
+++ b/src/main/java/com/momo/profile/entity/Profile.java
@@ -44,7 +44,6 @@ public class Profile extends BaseEntity {
   @Column(nullable = false)
   private LocalDate birth;
 
-  @Column(nullable = false)
   private String profileImageUrl;
 
   private String introduction;

--- a/src/test/java/com/momo/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/momo/profile/service/ProfileServiceTest.java
@@ -71,12 +71,11 @@ class ProfileServiceTest {
   void createProfile_WithoutImage_Success() {
     // given
     ProfileCreateRequest request = createProfileRequest();
-    String imageUrl = "default-image-url.jpg";
     User user = createUser();
-    Profile profile = request.toEntity(user, imageUrl);
+    Profile profile = request.toEntity(user, null);
 
     when(profileRepository.existsByUser_Id(user.getId())).thenReturn(false);
-    when(profileImageService.getImageUrl(null)).thenReturn(imageUrl);
+    when(profileImageService.getImageUrl(null)).thenReturn(null);
     when(profileRepository.save(any(Profile.class))).thenReturn(profile);
 
     // when
@@ -89,7 +88,7 @@ class ProfileServiceTest {
 
     assertThat(response.getGender()).isEqualTo(request.getGender());
     assertThat(response.getBirth()).isEqualTo(request.getBirth());
-    assertThat(response.getProfileImageUrl()).isEqualTo(imageUrl);
+    assertThat(response.getProfileImageUrl()).isEqualTo(null);
     assertThat(response.getMbti()).isEqualTo(request.getMbti());
   }
 


### PR DESCRIPTION
📌 관련 이슈
- close #151

## 📝 변경 사항
### AS-IS
- 프로필 이미지 없이 프로필 생성 불가

### TO-BE
- Profile Entity의 profileImageUrl 필드의 nullable=false 어노테이션 제거

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.