### PR TITLE
[bug] 모임과 채팅 생성시 회원탈퇴가 진행되지 않는 오류

### DIFF
--- a/src/main/java/com/momo/chat/repository/ChatReadStatusRepository.java
+++ b/src/main/java/com/momo/chat/repository/ChatReadStatusRepository.java
@@ -3,6 +3,9 @@ package com.momo.chat.repository;
 import com.momo.chat.entity.ChatReadStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,5 +16,9 @@ public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus, 
   void deleteByUserIdAndChatRoomId(Long userId, Long chatRoomId);
 
   void deleteByChatRoomId(Long chatRoomId);
+
+  @Modifying
+  @Query("DELETE FROM ChatReadStatus crs WHERE crs.user.id = :userId")
+  void deleteByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/com/momo/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/momo/chat/repository/ChatRoomRepository.java
@@ -22,4 +22,18 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   @Modifying
   @Query("DELETE FROM ChatRoom cr WHERE cr.meeting.id IN :meetingIds")
   int deleteAllByMeetingIds(@Param("meetingIds") List<Long> meetingIds);
+
+  // 유저가 생성한 채팅방 삭제
+  @Modifying
+  @Query("DELETE FROM ChatRoom cr WHERE cr.host.id = :userId")
+  void deleteByHostId(@Param("userId") Long userId);
+
+  // 유저를 채팅방에서 제거
+  default void removeUserFromChatRooms(User user) {
+    List<ChatRoom> chatRooms = findAllByReaderContains(user);
+    for (ChatRoom chatRoom : chatRooms) {
+      chatRoom.getReader().remove(user);
+    }
+    saveAll(chatRooms); // 변경 사항 저장
+  }
 }

--- a/src/main/java/com/momo/meeting/entity/Meeting.java
+++ b/src/main/java/com/momo/meeting/entity/Meeting.java
@@ -25,6 +25,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -42,6 +44,7 @@ public class Meeting extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private User user;
 
   @Column(nullable = false, length = 60)

--- a/src/main/java/com/momo/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/momo/meeting/repository/MeetingRepository.java
@@ -154,4 +154,15 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
   @Modifying
   @Query("DELETE FROM Meeting m WHERE m.id IN :meetingIds")
   int deleteAllByMeetingIds(@Param("meetingIds") List<Long> meetingIds);
+
+  // 먼저 MEETING_CATEGORY 데이터 삭제
+  @Modifying
+  @Query(value = "DELETE FROM meeting_category WHERE meeting_id IN (SELECT id FROM meeting WHERE user_id = :userId)", nativeQuery = true)
+  void deleteCategoriesByUserId(@Param("userId") Long userId);
+
+
+  // 사용자가 생성한 모든 미팅 삭제
+  @Modifying
+  @Query("DELETE FROM Meeting m WHERE m.user.id = :userId")
+  void deleteByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 모임 정보와 채팅정보가 존재하면 회원탈퇴가 진행되지 않는 오류 존재

### TO-BE
- UserService 에서 회원 탈퇴를 관리하는 로직에서 회원정보를 차례대로 삭제할 수 있도록 로직 추가
- 추가한 로직 : ChatReadStatus 삭제/ ChatRoom에서 해당 사용자 제거/ 유저가 생성한 채팅방 삭제/  유저가 생성한 Meeting의 카테고리 먼저 삭제/ 유저가 생성한 Meeting 삭제

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷

- 탈퇴 처리 전
<img width="643" alt="탈퇴 전 회원 정보" src="https://github.com/user-attachments/assets/c44ac766-f07c-45f6-8b86-c007b7a96284" />
<img width="643" alt="탈퇴 전 프로필" src="https://github.com/user-attachments/assets/f20e9981-da26-430a-9171-5c952fcee6a4" />
<img width="643" alt="탈퇴 전 모임정보" src="https://github.com/user-attachments/assets/cc01cc46-de12-487f-b7e6-b4c6e696c1a1" />
<img width="643" alt="탈퇴 전 모임카테고리" src="https://github.com/user-attachments/assets/c9ca238e-f063-44f9-a51c-58f7e13a5ad1" />


- 탈퇴 처리 후
<img width="643" alt="탈퇴 후 회원 정보" src="https://github.com/user-attachments/assets/4574bbba-c475-4284-a22e-d7dda2ab0f7a" />
<img width="643" alt="탈퇴 후 프로필" src="https://github.com/user-attachments/assets/1726f53e-a2e3-497e-8be0-974183433cb4" />
<img width="643" alt="탈퇴 후 모임정보" src="https://github.com/user-attachments/assets/f9a0015b-5218-4c69-859f-455b4ae5e92a" />
<img width="643" alt="탈퇴 후 모임카테고리" src="https://github.com/user-attachments/assets/ea462073-8ec7-426f-a30a-d53c6c1f326d" />




## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
확인부탁드립니다.