### PR TITLE
[fix] 회원정보 수정기능 관련 수정

### DIFF
--- a/src/main/java/com/momo/image/service/ImageService.java
+++ b/src/main/java/com/momo/image/service/ImageService.java
@@ -35,4 +35,11 @@ public class ImageService {
       throw new ProfileException(ProfileErrorCode.INVALID_IMAGE_FORMAT);
     }
   }
+
+  // 기존 프로필 이미지 삭제
+  public void deleteImage(String fileKey) {
+    if (fileKey != null && !fileKey.isEmpty()) {
+      imageStorage.deleteImage(fileKey);
+    }
+  }
 }

--- a/src/main/java/com/momo/user/controller/UserController.java
+++ b/src/main/java/com/momo/user/controller/UserController.java
@@ -20,7 +20,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -71,10 +73,12 @@ public class UserController {
     return ResponseEntity.ok(userInfo);
   }
 
-  // 회원정보 수정
   @PutMapping("/me")
-  public ResponseEntity<String> updateUser(@RequestBody UserUpdateRequest updateRequest) {
-    userService.updateUser(updateRequest);
+  public ResponseEntity<String> updateUser(
+      @RequestPart UserUpdateRequest updateRequest,
+      @RequestPart(required = false) MultipartFile profileImage
+  ) {
+    userService.updateUser(updateRequest, profileImage);
     return ResponseEntity.ok("회원정보가 성공적으로 수정되었습니다.");
   }
 

--- a/src/main/java/com/momo/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/momo/user/dto/UserUpdateRequest.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 public class UserUpdateRequest {
   private String nickname;
   private String phone;
-  private String profileImageUrl;
   private String introduction;
   private Mbti mbti;
 }

--- a/src/main/java/com/momo/user/service/UserService.java
+++ b/src/main/java/com/momo/user/service/UserService.java
@@ -133,23 +133,6 @@ public class UserService {
   }
 
 
-
-
-  // 비밀번호 재설정 토큰 생성
-  public String generateResetToken(String email) {
-    User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-    String token = UUID.randomUUID().toString();
-    passwordResetTokens.put(token, email);
-    return token;
-  }
-
-  // 비밀번호 재설정 토큰 검증
-  public boolean validateResetToken(String token) {
-    return passwordResetTokens.containsKey(token);
-  }
-
   // 비밀번호 재설정 링크 발송
   public void sendPasswordResetLink(String email) {
     User user = userRepository.findByEmail(email)
@@ -179,13 +162,6 @@ public class UserService {
     passwordResetTokens.remove(token);
   }
 
-  // 현재 로그인한 사용자 정보 가져오기
-  private CustomUserDetails getLoggedInUserDetails() {
-    return (CustomUserDetails) SecurityContextHolder
-        .getContext()
-        .getAuthentication()
-        .getPrincipal();
-  }
 
   @Transactional
   public User processKakaoUser(KakaoProfile kakaoProfile, OAuthToken oauthToken) {
@@ -246,28 +222,8 @@ public class UserService {
     createRefreshToken(user, newTokenValue);
   }
 
-  public UserInfoResponse getUserInfo() {
-    String email = SecurityContextHolder.getContext().getAuthentication().getName();
 
-    User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new RuntimeException("User not found"));
-
-    Profile profile = profileRepository.findByUser(user)
-        .orElseThrow(() -> new RuntimeException("Profile not found"));
-
-    return UserInfoResponse.builder()
-        .nickname(user.getNickname())
-        .phone(user.getPhone())
-        .email(user.getEmail())
-        .gender(profile.getGender())
-        .birth(profile.getBirth())
-        .profileImageUrl(profile.getProfileImageUrl())
-        .introduction(profile.getIntroduction())
-        .mbti(profile.getMbti())
-        .build();
-  }
-
-  // 카카오 로그인 회원정보 조회
+  // 회원정보 조회
   public UserInfoResponse getUserInfoByEmail(String email) {
     // User 엔티티 조회
     User user = userRepository.findByEmail(email)

--- a/src/main/java/com/momo/user/service/UserService.java
+++ b/src/main/java/com/momo/user/service/UserService.java
@@ -310,10 +310,15 @@ public class UserService {
     if (updateRequest.getPhone() != null) {
       user.setPhone(updateRequest.getPhone());
     }
-    userRepository.save(user);
 
     // Profile 엔티티 업데이트
     if (profileImage != null && !profileImage.isEmpty()) {
+      // 기존 프로필 이미지가 있다면 S3에서 삭제
+      if (profile.getProfileImageUrl() != null && !profile.getProfileImageUrl().isEmpty()) {
+        imageService.deleteImage(profile.getProfileImageUrl());
+      }
+
+      // 새 프로필 이미지 업로드 및 저장
       String profileImageUrl = imageService.getImageUrl(profileImage);
       profile.setProfileImageUrl(profileImageUrl);
     }
@@ -323,7 +328,6 @@ public class UserService {
     if (updateRequest.getMbti() != null) {
       profile.setMbti(updateRequest.getMbti());
     }
-    profileRepository.save(profile);
 
     log.debug("User and Profile updated successfully for email: {}", email);
   }

--- a/src/main/java/com/momo/user/service/UserService.java
+++ b/src/main/java/com/momo/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.momo.common.exception.ErrorCode;
 import com.momo.config.JWTUtil;
 import com.momo.config.token.entity.RefreshToken;
 import com.momo.config.token.repository.RefreshTokenRepository;
+import com.momo.image.service.ImageService;
 import com.momo.meeting.repository.MeetingRepository;
 import com.momo.profile.entity.Profile;
 import com.momo.profile.exception.ProfileErrorCode;
@@ -34,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -50,6 +52,7 @@ public class UserService {
   private final ChatReadStatusRepository chatReadStatusRepository;
   private final ChatRoomRepository chatRoomRepository;
   private final MeetingRepository meetingRepository;
+  private final ImageService imageService;
 
   private final HashMap<String, String> passwordResetTokens = new HashMap<>();
 
@@ -289,7 +292,7 @@ public class UserService {
   }
 
   @Transactional
-  public void updateUser(UserUpdateRequest updateRequest) {
+  public void updateUser(UserUpdateRequest updateRequest, MultipartFile profileImage) {
     String email = SecurityContextHolder.getContext().getAuthentication().getName();
 
     // User 엔티티 조회
@@ -310,8 +313,9 @@ public class UserService {
     userRepository.save(user);
 
     // Profile 엔티티 업데이트
-    if (updateRequest.getProfileImageUrl() != null) {
-      profile.setProfileImageUrl(updateRequest.getProfileImageUrl());
+    if (profileImage != null && !profileImage.isEmpty()) {
+      String profileImageUrl = imageService.getImageUrl(profileImage);
+      profile.setProfileImageUrl(profileImageUrl);
     }
     if (updateRequest.getIntroduction() != null) {
       profile.setIntroduction(updateRequest.getIntroduction());


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 회원 정보 수정 사항의 이미지를 url 로 넘기고 있음
- 회원 정보 수정 사항들을 body 에 JSON raw 형태로 입력받고 있음.

### TO-BE
- 회원정보 수정 시 이미지를 파일 자체로 넘길 수 있도록 수정
- 회원정보 수정 사항을 FormData 형식으로 보낼 수 있도록 수정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
<img width="749" alt="스크린샷 2025-01-21 오전 3 06 08" src="https://github.com/user-attachments/assets/aa28378e-52a6-4233-a3bc-97f39fb87ec5" />
<img width="749" alt="스크린샷 2025-01-21 오전 3 06 17" src="https://github.com/user-attachments/assets/12f59923-abed-4589-bdd4-83c79c0c1436" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
확인부탁드립니다.
