### PR TITLE
[Fix]: 회원탈퇴 시 데이터 삭제 버그 수정

### DIFF
--- a/src/main/java/com/momo/chat/repository/ChatReadStatusRepository.java
+++ b/src/main/java/com/momo/chat/repository/ChatReadStatusRepository.java
@@ -1,11 +1,9 @@
 package com.momo.chat.repository;
 
 import com.momo.chat.entity.ChatReadStatus;
+import com.momo.chat.entity.ChatRoom;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,8 +15,7 @@ public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus, 
 
   void deleteByChatRoomId(Long chatRoomId);
 
-  @Modifying
-  @Query("DELETE FROM ChatReadStatus crs WHERE crs.user.id = :userId")
-  void deleteByUserId(@Param("userId") Long userId);
+  void deleteByChatRoom(ChatRoom chatRoom);
 
+  void deleteByChatRoom_IdAndUser_Id(Long chatRoomId, Long userId);
 }

--- a/src/main/java/com/momo/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/momo/chat/repository/ChatRoomRepository.java
@@ -1,6 +1,7 @@
 package com.momo.chat.repository;
 
 import com.momo.chat.entity.ChatRoom;
+import com.momo.meeting.entity.Meeting;
 import com.momo.user.entity.User;
 import java.util.List;
 import java.util.Optional;
@@ -23,17 +24,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   @Query("DELETE FROM ChatRoom cr WHERE cr.meeting.id IN :meetingIds")
   int deleteAllByMeetingIds(@Param("meetingIds") List<Long> meetingIds);
 
-  // 유저가 생성한 채팅방 삭제
-  @Modifying
-  @Query("DELETE FROM ChatRoom cr WHERE cr.host.id = :userId")
-  void deleteByHostId(@Param("userId") Long userId);
-
-  // 유저를 채팅방에서 제거
-  default void removeUserFromChatRooms(User user) {
-    List<ChatRoom> chatRooms = findAllByReaderContains(user);
-    for (ChatRoom chatRoom : chatRooms) {
-      chatRoom.getReader().remove(user);
-    }
-    saveAll(chatRooms); // 변경 사항 저장
-  }
+  List<ChatRoom> findByMeeting(Meeting meeting);
 }

--- a/src/main/java/com/momo/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/momo/meeting/repository/MeetingRepository.java
@@ -165,4 +165,8 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
   @Modifying
   @Query("DELETE FROM Meeting m WHERE m.user.id = :userId")
   void deleteByUserId(@Param("userId") Long userId);
+
+  // 사용자가 생성한 미팅을 모두 찾기
+  @Query("SELECT m FROM Meeting m WHERE m.user.id = :userId")
+  List<Meeting> findByUserId(Long userId);
 }

--- a/src/main/java/com/momo/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/momo/participation/repository/ParticipationRepository.java
@@ -86,4 +86,11 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
   @Modifying
   @Query("DELETE FROM Participation p WHERE p.meeting.id IN :meetingIds")
   int deleteAllByMeetingIds(@Param("meetingIds") List<Long> meetingIds);
+
+  List<Participation> findByUserId(Long userId);
+
+  // 특정 미팅에 대한 모든 참여자 삭제
+  @Modifying
+  @Query("DELETE FROM Participation p WHERE p.meeting.id = :meetingId")
+  void deleteByMeetingId(Long meetingId);
 }


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 회원탈퇴 시 남아있는 데이터로 탈퇴 불가

### TO-BE
- 회원탈퇴 가능

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
// 탈퇴하려는 사용자가 호스트인 경우 (모임 및 채팅방 삭제)
// 탈퇴하려는 사용자가 참여자일 경우 (참여자 정보 삭제)
두가지 경우로 나누어서 로직 작성했습니다.
![image](https://github.com/user-attachments/assets/263b4daa-dabf-4025-b985-52c7b122daae)
meeting 테이블의 경우, 참여자가 탈퇴할 경우 추가 수정이 필요합니다.
(approved_count와 모집상태 변경 등)