### PR TITLE
[fix] 참여 신청한 모임 목록 조회에서 thumbnail 필드의 이름이 통일되지 않아 오류 발생

### DIFF
--- a/src/main/java/com/momo/participation/dto/AppliedMeetingDto.java
+++ b/src/main/java/com/momo/participation/dto/AppliedMeetingDto.java
@@ -61,7 +61,7 @@ public class AppliedMeetingDto {
         .approvedCount(appliedMeeting.getApprovedCount())
         .category(foodCategories)
         .content(appliedMeeting.getContent())
-        .thumbnail(appliedMeeting.getThumbnailUrl())
+        .thumbnail(appliedMeeting.getThumbnail())
         .build();
   }
 }

--- a/src/main/java/com/momo/participation/projection/AppliedMeetingProjection.java
+++ b/src/main/java/com/momo/participation/projection/AppliedMeetingProjection.java
@@ -33,5 +33,5 @@ public interface AppliedMeetingProjection {
 
   String getContent();
 
-  String getThumbnailUrl();
+  String getThumbnail();
 }

--- a/src/main/java/com/momo/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/momo/participation/repository/ParticipationRepository.java
@@ -35,7 +35,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
           + "m.approved_count as approvedCount, "
           + "categories.categories as category, "
           + "m.content as content, "
-          + "m.thumbnail_url as thumbnailUrl "
+          + "m.thumbnail as thumbnail "
           + "FROM participation p "
           + "INNER JOIN meeting m ON p.meeting_id = m.id "
           + "INNER JOIN ("

--- a/src/test/java/com/momo/participation/service/ParticipationServiceTest.java
+++ b/src/test/java/com/momo/participation/service/ParticipationServiceTest.java
@@ -364,7 +364,7 @@ class ParticipationServiceTest {
     given(projection.getApprovedCount()).willReturn(i + 1);
     given(projection.getCategory()).willReturn("KOREAN,DESSERT");
     given(projection.getContent()).willReturn("Test Content " + i);
-    given(projection.getThumbnailUrl()).willReturn("test_" + i + "_thumbnail_url.jpg");
+    given(projection.getThumbnail()).willReturn("test_" + i + "_thumbnail_url.jpg");
     projections.add(projection);
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #158 

## 📝 변경 사항
### AS-IS
- 참여 신청한 모임 목록 조회에서 thumbnail 필드의 이름이 통일되지 않아 오류 발생

### TO-BE
- 썸네일 필드의 이름을 모두 thumbnail로 통일하도록 수정

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.