### PR TITLE
[Fix]: 만료된 모임 삭제시 버그 수정

### DIFF
--- a/src/main/java/com/momo/chat/repository/ChatReadStatusRepository.java
+++ b/src/main/java/com/momo/chat/repository/ChatReadStatusRepository.java
@@ -2,8 +2,12 @@ package com.momo.chat.repository;
 
 import com.momo.chat.entity.ChatReadStatus;
 import com.momo.chat.entity.ChatRoom;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,4 +22,8 @@ public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus, 
   void deleteByChatRoom(ChatRoom chatRoom);
 
   void deleteByChatRoom_IdAndUser_Id(Long chatRoomId, Long userId);
+
+  @Modifying
+  @Query("DELETE FROM ChatReadStatus crs WHERE crs.chatRoom.id IN :chatRoomIds")
+  void deleteAllByChatRoomIds(@Param("chatRoomIds") List<Long> chatRoomIds);
 }

--- a/src/main/java/com/momo/chat/repository/ChatRepository.java
+++ b/src/main/java/com/momo/chat/repository/ChatRepository.java
@@ -3,6 +3,9 @@ package com.momo.chat.repository;
 import com.momo.chat.entity.Chat;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +15,7 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
 
   void deleteByChatRoomId(Long chatRoomId);
 
+  @Modifying
+  @Query("DELETE FROM Chat c WHERE c.chatRoom.id IN :chatRoomIds")
+  void deleteAllByChatRoomIds(@Param("chatRoomIds") List<Long> chatRoomIds);
 }

--- a/src/main/java/com/momo/meeting/service/MeetingService.java
+++ b/src/main/java/com/momo/meeting/service/MeetingService.java
@@ -1,5 +1,7 @@
 package com.momo.meeting.service;
 
+import com.momo.chat.repository.ChatReadStatusRepository;
+import com.momo.chat.repository.ChatRepository;
 import com.momo.chat.repository.ChatRoomRepository;
 import com.momo.chat.service.ChatRoomService;
 import com.momo.meeting.constant.MeetingStatus;
@@ -54,6 +56,8 @@ public class MeetingService {
   private final MeetingRepository meetingRepository;
   private final ParticipationRepository participationRepository;
   private final ChatRoomRepository chatRoomRepository;
+  private final ChatReadStatusRepository chatReadStatusRepository;
+  private final ChatRepository chatRepository;
 
   private final ChatRoomService chatRoomService;
   private final NotificationService notificationService;
@@ -211,6 +215,8 @@ public class MeetingService {
   private void deleteExpiredMeetingData(List<Long> expiredMeetingIds) {
     // Scheduled의 쓰레드에서는 Transaction을 실행할 수 없기 때문에 직접 실행
     transactionTemplate.execute(status -> {
+      chatReadStatusRepository.deleteAllByChatRoomIds(expiredMeetingIds);
+      chatRepository.deleteAllByChatRoomIds(expiredMeetingIds);
       int deleteChatRoomCount = chatRoomRepository.deleteAllByMeetingIds(expiredMeetingIds);
       int deleteParticipationCount =
           participationRepository.deleteAllByMeetingIds(expiredMeetingIds);


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 만료된 모임 삭제시 
Cannot delete or update a parent row: a foreign key constraint fails (`momo`.`chat_read_status`, CONSTRAINT `FKc0i41iogah5mcjpqbi1erc8m5` FOREIGN KEY (`chat_room_id`) REFERENCES `chat_room` (`id`))

### TO-BE
- 만료된 모임 삭제 가능

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
chatReadStatusRepository 와 chatRepository 삭제 후, chatRoomRepository가 삭제됩니다.