### PR TITLE
[Feature] 참여신청 승인 서비스 로직 트랜잭션 어노테이션 추가

### DIFF
--- a/src/main/java/com/momo/participation/service/ParticipationService.java
+++ b/src/main/java/com/momo/participation/service/ParticipationService.java
@@ -9,7 +9,6 @@ import com.momo.meeting.entity.Meeting;
 import com.momo.meeting.exception.MeetingErrorCode;
 import com.momo.meeting.exception.MeetingException;
 import com.momo.meeting.repository.MeetingRepository;
-import com.momo.notification.constant.NotificationCategory;
 import com.momo.notification.constant.NotificationType;
 import com.momo.notification.service.NotificationService;
 import com.momo.participation.constant.ParticipationStatus;
@@ -56,6 +55,7 @@ public class ParticipationService {
     );
   }
 
+  @Transactional
   public void approveParticipation(Long authorId, Long participationId) {
     Participation participation = updateApproveParticipation(authorId, participationId);
     joinChatRoom(participation.getMeeting(), participation); // 채팅방 입장


### PR DESCRIPTION
## 📌 관련 이슈
- close #이슈번호

## 📝 변경 사항
### AS-IS
- 참여신청 승인 시, 참여 승인 로직과 채팅방 입장 로직 트랜잭션이 각각 독립적으로 동작

### TO-BE
- 참여신청 승인 서비스 로직 트랜잭션 어노테이션을 추가하여 하나의 트랜잭션으로 동작하도록 설정

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.