### PR TITLE
[refactor] 신청한 모임 목록 조회의 응답값의 id의 필드 이름을 'participationId'로 변경

### DIFF
--- a/src/main/java/com/momo/participation/dto/AppliedMeetingDto.java
+++ b/src/main/java/com/momo/participation/dto/AppliedMeetingDto.java
@@ -15,7 +15,7 @@ import lombok.Getter;
 @Builder
 public class AppliedMeetingDto {
 
-  private Long id;
+  private Long participationId;
   private Long meetingId;
   private Long authorId;
   private ParticipationStatus participationStatus;
@@ -47,7 +47,7 @@ public class AppliedMeetingDto {
     Set<String> foodCategories = FoodCategory.convertToFoodCategories(appliedMeeting.getCategory());
 
     return AppliedMeetingDto.builder()
-        .id(appliedMeeting.getId())
+        .participationId(appliedMeeting.getId())
         .meetingId(appliedMeeting.getMeetingId())
         .authorId(appliedMeeting.getAuthorId())
         .participationStatus(appliedMeeting.getParticipationStatus())

--- a/src/main/java/com/momo/participation/dto/AppliedMeetingsResponse.java
+++ b/src/main/java/com/momo/participation/dto/AppliedMeetingsResponse.java
@@ -26,7 +26,7 @@ public class AppliedMeetingsResponse {
         appliedMeetingDtos.subList(0, pageSize) :
         appliedMeetingDtos.subList(0, appliedMeetingDtos.size());
 
-    Long lastId = hasNext ? appliedMeetingDtos.get(appliedMeetingDtos.size() - 1).getId() : null;
+    Long lastId = hasNext ? appliedMeetingDtos.get(appliedMeetingDtos.size() - 1).getParticipationId() : null;
 
     return AppliedMeetingsResponse.builder()
         .lastId(lastId)

--- a/src/test/java/com/momo/participation/service/ParticipationServiceTest.java
+++ b/src/test/java/com/momo/participation/service/ParticipationServiceTest.java
@@ -375,7 +375,7 @@ class ParticipationServiceTest {
   }
 
   private static void AssertThatAppliedMeeting(List<AppliedMeetingDto> appliedMeetings, int i) {
-    assertThat(appliedMeetings.get(i).getId()).isEqualTo(i);
+    assertThat(appliedMeetings.get(i).getParticipationId()).isEqualTo(i);
     assertThat(appliedMeetings.get(i).getMeetingId()).isEqualTo(i * 10L);
     assertThat(appliedMeetings.get(i).getAuthorId()).isEqualTo(i * 100L);
     assertThat(appliedMeetings.get(i).getParticipationStatus())


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 신청한 모임 목록 조회의 응답값의 id의 필드 이름이 'id'

### TO-BE
- 신청한 모임 목록 조회의 응답값의 id의 필드 이름을 'participationId'로 변경

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.