### PR TITLE
[ fix ] 프로필 이미지 초기화

### DIFF
--- a/src/main/java/com/momo/user/service/UserService.java
+++ b/src/main/java/com/momo/user/service/UserService.java
@@ -312,17 +312,22 @@ public class UserService {
       user.setPhone(updateRequest.getPhone());
     }
 
-    // Profile 엔티티 업데이트
-    if (profileImage != null && !profileImage.isEmpty()) {
+    // Profile 이미지 업데이트 (imageService 사용)
+    String profileImageUrl = imageService.uploadImageProcess(profileImage);
+
+    if (profileImageUrl != null) {
       // 기존 프로필 이미지가 있다면 S3에서 삭제
       if (profile.getProfileImageUrl() != null && !profile.getProfileImageUrl().isEmpty()) {
         imageService.deleteImage(profile.getProfileImageUrl());
       }
-
-      // 새 프로필 이미지 업로드 및 저장
-      String profileImageUrl = imageService.uploadImageProcess(profileImage);
+      // 새 프로필 이미지 업로드 후 저장
       profile.setProfileImageUrl(profileImageUrl);
+    } else {
+      // 프로필 이미지가 업로드되지 않은 경우, 기본 이미지로 설정하거나 null 유지
+      profile.setProfileImageUrl(null); // 기본 이미지가 있으면 여기서 설정
     }
+
+    // Profile 추가 정보 업데이트
     if (updateRequest.getIntroduction() != null) {
       profile.setIntroduction(updateRequest.getIntroduction());
     }


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 프로필 수정시 프로필 기본 이미지로 설정하는 값이 존재하지 않음.

### TO-BE
- 프로필 수정시 프로필 이미지를 초기화할 수 있도록 수정
- 삽입된 프로필 이미지가 없다면 null 반환하여 기본이미지로 설정될 수 있도록 수정

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## ✅ 체크리스트
- [ ] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
확인부탁드립니다.
