### PR TITLE
[Feature] 모임 삭제 시 관련 데이터 함께 삭제되도록 수정 

### DIFF
--- a/src/main/java/com/momo/chat/service/ChatRoomService.java
+++ b/src/main/java/com/momo/chat/service/ChatRoomService.java
@@ -275,8 +275,6 @@ public class ChatRoomService {
     chatReadStatusRepository.deleteByChatRoomId(chatRoomId);
     chatRepository.deleteByChatRoomId(chatRoomId);
     chatRoomRepository.delete(chatRoom);
-
-    // TODO: 채팅방 삭제시 모임삭제 되도록
   }
 
   // 특정 사용자 강퇴 (호스트만 가능)


### PR DESCRIPTION
## 📌 관련 이슈
- close #169 

## 📝 변경 사항
### AS-IS
- 모임 삭제 시 모임만 삭제

### TO-BE
- 모임 삭제 시 채팅방 삭제 (채팅방 관련 데이터 또한 삭제)
- 모임에 관련된 참여신청 모두 삭제
- 모임의 썸네일이 존재한다면 삭제

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 모임의 작성자가 아닐 때
![meeting-delete_fail](https://github.com/user-attachments/assets/6a948d9a-0652-4fe4-bab7-d36e95e6857a)
- 성공
![meeting-delete_success](https://github.com/user-attachments/assets/596f7055-95fc-4973-b3f4-1134c5597ce4)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.