### PR TITLE
[Feature] 모임에 참여 신청한 회원 목록 조회 시 participationId도 함께 반환되도록 수정

### DIFF
--- a/src/main/java/com/momo/meeting/projection/MeetingParticipantProjection.java
+++ b/src/main/java/com/momo/meeting/projection/MeetingParticipantProjection.java
@@ -6,6 +6,8 @@ public interface MeetingParticipantProjection {
 
   Long getUserId();
 
+  Long getParticipationId();
+
   String getNickname();
 
   String getProfileImage();

--- a/src/main/java/com/momo/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/momo/participation/repository/ParticipationRepository.java
@@ -57,6 +57,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
   // 해당 모임에 참여 신청한 회원 목록을 조회
   @Query(value = "SELECT "
       + "u.user_id as userId, "
+      + "mp.id as participationId, "
       + "u.nickname as nickname, "
       + "p.profile_image_url as profileImageUrl, "
       + "mp.participation_status as participationStatus "


### PR DESCRIPTION
## 📌 관련 이슈
- close #171 

## 📝 변경 사항
### AS-IS
- 모임에 참여 신청한 회원 목록 조회 시 participationId 없음

### TO-BE
- 모임에 참여 신청한 회원 목록 조회 시 participationId도 함께 반환되도록 수정

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
![meeting-get-participants](https://github.com/user-attachments/assets/3aa0377d-444e-4d23-9fa2-ce32d4950db0)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.