### PR TITLE
[docs] 회원정보 조회 로직 간결화

### DIFF
--- a/src/main/java/com/momo/user/dto/OtherUserInfoProjection.java
+++ b/src/main/java/com/momo/user/dto/OtherUserInfoProjection.java
@@ -1,0 +1,16 @@
+package com.momo.user.dto;
+
+import com.momo.profile.constant.Gender;
+import com.momo.profile.constant.Mbti;
+
+import java.time.LocalDate;
+
+// 다른 사용자 프로필 조회용 프로젝션
+public interface OtherUserInfoProjection {
+  String getNickname();
+  Gender getGender();             // Enum 타입
+  LocalDate getBirth();           // LocalDate 타입
+  Mbti getMbti();                 // Enum 타입
+  String getIntroduction();
+  String getProfileImageUrl();
+}

--- a/src/main/java/com/momo/user/dto/UserInfoProjection.java
+++ b/src/main/java/com/momo/user/dto/UserInfoProjection.java
@@ -1,0 +1,19 @@
+package com.momo.user.dto;
+
+import com.momo.profile.constant.Gender;
+import com.momo.profile.constant.Mbti;
+
+import java.time.LocalDate;
+
+// 본인 정보 조회용 프로젝션
+public interface UserInfoProjection {
+  String getNickname();
+  String getPhone();
+  String getEmail();
+  Gender getGender();             // Enum 타입
+  LocalDate getBirth();           // LocalDate 타입
+  String getProfileImageUrl();
+  String getIntroduction();
+  Mbti getMbti();                 // Enum 타입
+  boolean isOauthUser();          // OAuth 여부
+}

--- a/src/main/java/com/momo/user/repository/UserRepository.java
+++ b/src/main/java/com/momo/user/repository/UserRepository.java
@@ -1,8 +1,11 @@
 package com.momo.user.repository;
 
+import com.momo.user.dto.OtherUserInfoProjection;
+import com.momo.user.dto.UserInfoProjection;
 import com.momo.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -15,6 +18,21 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
 
   Optional<User> findById(Long userId);
+
+  // 본인 정보 조회 - User와 Profile을 JOIN하여 필요한 필드만 조회
+  @Query("SELECT u.nickname as nickname, u.phone as phone, u.email as email, " +
+      "p.gender as gender, p.birth as birth, p.profileImageUrl as profileImageUrl, " +
+      "p.introduction as introduction, p.mbti as mbti, u.oauthUser as oauthUser " +
+      "FROM User u JOIN Profile p ON u.id = p.user.id " +
+      "WHERE u.email = :email")
+  Optional<UserInfoProjection> findUserInfoByEmail(String email);
+
+  // 다른 사용자 프로필 조회 - User와 Profile을 JOIN하여 필요한 필드만 조회
+  @Query("SELECT u.nickname as nickname, p.gender as gender, p.birth as birth, " +
+      "p.mbti as mbti, p.introduction as introduction, p.profileImageUrl as profileImageUrl " +
+      "FROM User u JOIN Profile p ON u.id = p.user.id " +
+      "WHERE u.id = :userId")
+  Optional<OtherUserInfoProjection> findOtherUserProfileById(Long userId);
 
 }
 

--- a/src/main/java/com/momo/user/service/UserService.java
+++ b/src/main/java/com/momo/user/service/UserService.java
@@ -23,7 +23,9 @@ import com.momo.profile.exception.ProfileErrorCode;
 import com.momo.profile.exception.ProfileException;
 import com.momo.profile.repository.ProfileRepository;
 import com.momo.user.dto.CustomUserDetails;
+import com.momo.user.dto.OtherUserInfoProjection;
 import com.momo.user.dto.OtherUserInfoResponse;
+import com.momo.user.dto.UserInfoProjection;
 import com.momo.user.dto.UserInfoResponse;
 import com.momo.user.dto.UserUpdateRequest;
 import com.momo.user.entity.User;
@@ -268,27 +270,21 @@ public class UserService {
   }
 
 
-  // 회원정보 조회
+  // 본인 정보 조회
   public UserInfoResponse getUserInfoByEmail(String email) {
-    // User 엔티티 조회
-    User user = userRepository.findByEmail(email)
+    UserInfoProjection projection = userRepository.findUserInfoByEmail(email)
         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-    // Profile 엔티티 조회
-    Profile profile = profileRepository.findByUser(user)
-        .orElseThrow(() -> new ProfileException(ProfileErrorCode.NOT_EXISTS_PROFILE));
-
-    // UserInfoResponse 생성 및 반환
     return UserInfoResponse.builder()
-        .nickname(user.getNickname())
-        .phone(user.getPhone())
-        .email(user.getEmail())
-        .gender(profile.getGender())
-        .birth(profile.getBirth())
-        .profileImageUrl(profile.getProfileImageUrl())
-        .introduction(profile.getIntroduction())
-        .mbti(profile.getMbti())
-        .oauthProvider(user.isOauthUser() ? "KAKAO" : "LOCAL") // 회원 타입 구분
+        .nickname(projection.getNickname())
+        .phone(projection.getPhone())
+        .email(projection.getEmail())
+        .gender(projection.getGender())
+        .birth(projection.getBirth())
+        .profileImageUrl(projection.getProfileImageUrl())
+        .introduction(projection.getIntroduction())
+        .mbti(projection.getMbti())
+        .oauthProvider(projection.isOauthUser() ? "KAKAO" : "LOCAL")
         .build();
   }
 
@@ -338,25 +334,21 @@ public class UserService {
     log.debug("User and Profile updated successfully for email: {}", email);
   }
 
+  // 다른 사용자 프로필 조회
   @Transactional
   public OtherUserInfoResponse getOtherUserProfile(Long userId) {
-    // User 엔티티 조회
-    User user = userRepository.findById(userId)
+    OtherUserInfoProjection projection = userRepository.findOtherUserProfileById(userId)
         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-    // Profile 엔티티 조회
-    Profile profile = profileRepository.findByUser(user)
-        .orElseThrow(() -> new ProfileException(ProfileErrorCode.NOT_EXISTS_PROFILE));
-
-    // 필요한 정보만 반환
     return OtherUserInfoResponse.builder()
-        .nickname(user.getNickname())
-        .gender(profile.getGender())
-        .birth(profile.getBirth())
-        .mbti(profile.getMbti())
-        .introduction(profile.getIntroduction())
-        .profileImageUrl(profile.getProfileImageUrl())
+        .nickname(projection.getNickname())
+        .gender(projection.getGender())
+        .birth(projection.getBirth())
+        .mbti(projection.getMbti())
+        .introduction(projection.getIntroduction())
+        .profileImageUrl(projection.getProfileImageUrl())
         .build();
   }
+
 
 }


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 기존에는 UserRepository.findByEmail(email)과 ProfileRepository.findByUser(user)를 별도로 호출
- User와 Profile 엔티티를 따로 조회하는 오버헤드 가능성 존재

### TO-BE
- join과 프로젝션 사용하여 필요한 필드만 한번에 가져오는 방법을 통해 로직 간결화
- 성능 향상

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 코드는 제거했나요?
- [ ] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
확인부탁드립니다.
