### PR TITLE
[refactor] 모임의 참여신청자 목록 조회 쿼리 메서드의 프로필 이미지의 alias를 profileImageUrl로 변경 

### DIFF
--- a/src/main/java/com/momo/meeting/projection/MeetingParticipantProjection.java
+++ b/src/main/java/com/momo/meeting/projection/MeetingParticipantProjection.java
@@ -10,7 +10,7 @@ public interface MeetingParticipantProjection {
 
   String getNickname();
 
-  String getProfileImageUrl();
+  String getProfileImage();
 
   ParticipationStatus getParticipationStatus();
 }

--- a/src/main/java/com/momo/meeting/projection/MeetingParticipantProjection.java
+++ b/src/main/java/com/momo/meeting/projection/MeetingParticipantProjection.java
@@ -10,7 +10,7 @@ public interface MeetingParticipantProjection {
 
   String getNickname();
 
-  String getProfileImage();
+  String getProfileImageUrl();
 
   ParticipationStatus getParticipationStatus();
 }

--- a/src/main/java/com/momo/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/momo/participation/repository/ParticipationRepository.java
@@ -59,7 +59,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
       + "u.user_id as userId, "
       + "mp.id as participationId, "
       + "u.nickname as nickname, "
-      + "p.profile_image_url as profileImageUrl, "
+      + "p.profile_image_url as profileImage, "
       + "mp.participation_status as participationStatus "
       + "FROM participation mp "
       + "JOIN users u ON mp.user_id = u.user_id "

--- a/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
@@ -47,7 +47,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import javax.swing.text.html.Option;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -680,7 +679,7 @@ class MeetingServiceTest {
     MeetingParticipantProjection projection = mock(MeetingParticipantProjection.class);
     given(projection.getUserId()).willReturn((long) i);
     given(projection.getNickname()).willReturn("test-nickname" + i);
-    given(projection.getProfileImage()).willReturn("test_" + i + "_profile_image_url.jpg");
+    given(projection.getProfileImageUrl()).willReturn("test_" + i + "_profile_image_url.jpg");
     given(projection.getParticipationStatus()).willReturn(ParticipationStatus.PENDING);
     projections.add(projection);
   }
@@ -697,7 +696,7 @@ class MeetingServiceTest {
   ) {
     assertThat(projections.get(i).getUserId()).isEqualTo(i);
     assertThat(projections.get(i).getNickname()).isEqualTo("test-nickname" + i);
-    assertThat(projections.get(i).getProfileImage())
+    assertThat(projections.get(i).getProfileImageUrl())
         .isEqualTo("test_" + i + "_profile_image_url.jpg");
     assertThat(projections.get(i).getParticipationStatus()).isEqualTo(ParticipationStatus.PENDING);
   }


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 모임의 참여신청자 목록 조회 쿼리에서는 프로필 이미지 URL 값을 profileImageUrl로 표시 중인데, 해당 반환값에 매핑되는 프로젝션에서는 getProfileImage을 필드 이름으로 사용 중이어서 해당 값이 null로 반환됨

### TO-BE
- 모임의 참여신청자 목록 조회 쿼리 메서드의 프로필 이미지의 alias를 profileImageUrl로 변경 

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
![meeting-participants](https://github.com/user-attachments/assets/6c6dfd24-9dec-4242-810d-7c68357d67ca)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.