### PR TITLE
[Feature] 모임 상태 변경 API를 모임 모집 완료 API로 수정

### DIFF
--- a/src/main/java/com/momo/meeting/controller/MeetingController.java
+++ b/src/main/java/com/momo/meeting/controller/MeetingController.java
@@ -166,20 +166,14 @@ public class MeetingController {
   }
 
   /**
-   * 모임 상태 변경
-   *
-   * @param customUserDetails 회원 정보
-   * @param meetingId         상태를 변경할 모임 ID
-   * @param meetingStatus     변경할 상태
-   * @return 200 OK
+   * 모집 완료
    */
-  @PatchMapping("/{meetingId}")
-  public ResponseEntity<Void> updateMeetingStatus(
+  @PatchMapping("/{meetingId}/complete")
+  public ResponseEntity<Void> completedMeeting(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
-      @PathVariable Long meetingId,
-      @RequestBody @NotNull MeetingStatusRequest meetingStatus
+      @PathVariable Long meetingId
   ) {
-    meetingService.updateMeetingStatus(customUserDetails.getId(), meetingId, meetingStatus);
+    meetingService.completedMeeting(customUserDetails.getId(), meetingId);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/com/momo/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/momo/participation/repository/ParticipationRepository.java
@@ -94,4 +94,12 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
   @Modifying
   @Query("DELETE FROM Participation p WHERE p.meeting.id = :meetingId")
   void deleteByMeetingId(Long meetingId);
+
+  @Modifying
+  @Query("UPDATE Participation p SET p.participationStatus = :newStatus "
+      + "WHERE p.meeting.id = :meetingId AND p.participationStatus  = :currentStatus")
+  void findAllByMeeting_IdAndParticipationStatus(
+      @Param("meetingId") Long meetingID,
+      @Param("currentStatus") ParticipationStatus currentStatus,
+      @Param("newStatus") ParticipationStatus newStatus);
 }

--- a/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/momo/meeting/service/MeetingServiceTest.java
@@ -37,6 +37,7 @@ import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
 import com.momo.meeting.repository.MeetingRepository;
 import com.momo.notification.service.NotificationService;
 import com.momo.participation.constant.ParticipationStatus;
+import com.momo.participation.entity.Participation;
 import com.momo.participation.repository.ParticipationRepository;
 import com.momo.user.entity.User;
 import java.time.LocalDate;
@@ -324,20 +325,17 @@ class MeetingServiceTest {
   }
 
   @Test
-  @DisplayName("모임 상태 변경  - 성공")
+  @DisplayName("모임 모집완료 - 성공")
   void updateMeetingStatus_Success() {
     // given
     User user = createUser();
     MeetingCreateRequest request = createMeetingRequest();
     Meeting meeting = createMeeting(user, request);
-    MeetingStatusRequest meetingStatus = MeetingStatusRequest.builder()
-        .meetingStatus(MeetingStatus.CLOSED)
-        .build();
 
     when(meetingRepository.findById(user.getId())).thenReturn(Optional.of(meeting));
 
     // when
-    meetingService.updateMeetingStatus(user.getId(), meeting.getId(), meetingStatus);
+    meetingService.completedMeeting(user.getId(), meeting.getId());
 
     // then
     assertEquals(MeetingStatus.CLOSED, meeting.getMeetingStatus());
@@ -679,7 +677,7 @@ class MeetingServiceTest {
     MeetingParticipantProjection projection = mock(MeetingParticipantProjection.class);
     given(projection.getUserId()).willReturn((long) i);
     given(projection.getNickname()).willReturn("test-nickname" + i);
-    given(projection.getProfileImageUrl()).willReturn("test_" + i + "_profile_image_url.jpg");
+    given(projection.getProfileImage()).willReturn("test_" + i + "_profile_image_url.jpg");
     given(projection.getParticipationStatus()).willReturn(ParticipationStatus.PENDING);
     projections.add(projection);
   }
@@ -696,7 +694,7 @@ class MeetingServiceTest {
   ) {
     assertThat(projections.get(i).getUserId()).isEqualTo(i);
     assertThat(projections.get(i).getNickname()).isEqualTo("test-nickname" + i);
-    assertThat(projections.get(i).getProfileImageUrl())
+    assertThat(projections.get(i).getProfileImage())
         .isEqualTo("test_" + i + "_profile_image_url.jpg");
     assertThat(projections.get(i).getParticipationStatus()).isEqualTo(ParticipationStatus.PENDING);
   }
@@ -708,6 +706,16 @@ class MeetingServiceTest {
         .meeting(meeting)
         .reader(new ArrayList<>(List.of(host)))
         .ChatMessages(new ArrayList<>())
+        .build();
+  }
+
+  private static Participation createParticipation(
+      User user, Meeting meeting, ParticipationStatus participationStatus
+  ) {
+    return Participation.builder()
+        .user(user)
+        .meeting(meeting)
+        .participationStatus(participationStatus)
         .build();
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #180 

## 📝 변경 사항
### AS-IS
- 현재 모임 상태를 변경하는 경우는 '모집 완료'일 때 밖에 없는데, 모임 상태를 직접 받아서 변경하고 있음
- 참여신청 중 참여상태가 'PENDING'인 신청에 대한 피드백 없음

### TO-BE
- 모임 상태를 변경하는 경우는 '모집 완료'일 때 밖에 없기 때문에 로직 내부에서 직접 모임의 상태를 'CLOSED'로 변경
- 해당 모임의 참여신청 중 참여상태가 'PENDING'인 신청은 'CLOSED'로 변경

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 해당 모임의 작성자가 아닌 경우
![meeting-complete_fail](https://github.com/user-attachments/assets/a5f9954e-2481-40e3-b374-4526ba00ef2c)
- 해당 모임이 존재하지 않는 경우
![meeting-complete_fail2](https://github.com/user-attachments/assets/942aa474-f976-4554-8b1c-6e30ed5a10e7)
- 성공
![meeting-complete_success](https://github.com/user-attachments/assets/380cebd1-4f66-42b6-8af5-2732a6a8d941)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.