### PR TITLE
[Feature] 모임 삭제 시 해당 모임에 참여신청한 모든 회원에게 알림 발송 로직 추가

### DIFF
--- a/src/main/java/com/momo/meeting/service/MeetingService.java
+++ b/src/main/java/com/momo/meeting/service/MeetingService.java
@@ -138,8 +138,9 @@ public class MeetingService {
     ChatRoom chatRoom = chatRoomRepository.findByMeeting_Id(meetingId)
         .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
-    chatRoomService.deleteRoom(meeting.getUser(), chatRoom.getId()); // 채팅방 삭제
     List<Participation> participations = participationRepository.findAllByMeeting_Id(meetingId);
+
+    chatRoomService.deleteRoom(meeting.getUser(), chatRoom.getId()); // 채팅방 삭제
     participationRepository.deleteByMeetingId(meetingId); // 참여신청 삭제
     meetingRepository.delete(meeting); // 모임 삭제
     imageService.deleteImage(meeting.getThumbnail()); // 모임 썸네일 삭제

--- a/src/main/java/com/momo/meeting/service/MeetingService.java
+++ b/src/main/java/com/momo/meeting/service/MeetingService.java
@@ -28,6 +28,7 @@ import com.momo.meeting.projection.MeetingToMeetingDtoProjection;
 import com.momo.notification.constant.NotificationType;
 import com.momo.notification.service.NotificationService;
 import com.momo.participation.constant.ParticipationStatus;
+import com.momo.participation.entity.Participation;
 import com.momo.participation.repository.ParticipationRepository;
 import com.momo.image.service.ImageService;
 import com.momo.user.entity.User;
@@ -136,11 +137,14 @@ public class MeetingService {
     Meeting meeting = validateForMeetingAuthor(userId, meetingId);
     ChatRoom chatRoom = chatRoomRepository.findByMeeting_Id(meetingId)
         .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
-    
+
     chatRoomService.deleteRoom(meeting.getUser(), chatRoom.getId()); // 채팅방 삭제
+    List<Participation> participations = participationRepository.findAllByMeeting_Id(meetingId);
     participationRepository.deleteByMeetingId(meetingId); // 참여신청 삭제
     meetingRepository.delete(meeting); // 모임 삭제
     imageService.deleteImage(meeting.getThumbnail()); // 모임 썸네일 삭제
+
+    sendMeetingCanceledNotifications(participations, meeting); // 모든 참여신청자에게 알림 발송
   }
 
   public MeetingsResponse getMeetings(MeetingsRequest request) {
@@ -326,6 +330,15 @@ public class MeetingService {
   private static void validateMeetingDate(LocalDateTime meetingDateTime) {
     if (meetingDateTime.isAfter(LocalDateTime.now().plusYears(1))) {
       throw new MeetingException(MeetingErrorCode.INVALID_MEETING_DATE);
+    }
+  }
+
+  private void sendMeetingCanceledNotifications(List<Participation> participations, Meeting meeting) {
+    for (Participation participation : participations) {
+      notificationService.sendNotification(
+          participation.getUser(),
+          meeting.getTitle() + NotificationType.MEETING_CANCELED.getDescription(),
+          NotificationType.MEETING_CANCELED);
     }
   }
 }

--- a/src/main/java/com/momo/notification/constant/NotificationType.java
+++ b/src/main/java/com/momo/notification/constant/NotificationType.java
@@ -13,6 +13,8 @@ public enum NotificationType {
 
   PARTICIPANT_LEFT("참가자 탈퇴", NotificationCategory.MEETING),
 
+  MEETING_CANCELED("모임이 취소되었습니다.", NotificationCategory.MEETING),
+
   MEETING_EXPIRED(
       "모임 시간이 만료되어 자동으로 삭제되었습니다.", NotificationCategory.MEETING),
 

--- a/src/main/java/com/momo/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/momo/participation/repository/ParticipationRepository.java
@@ -94,4 +94,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
   @Modifying
   @Query("DELETE FROM Participation p WHERE p.meeting.id = :meetingId")
   void deleteByMeetingId(Long meetingId);
+
+  List<Participation> findAllByMeeting_Id(Long meetingId);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #182 

## 📝 변경 사항
### AS-IS
- 모임 삭제 시 참여신청한 회원들에게 아무런 피드백 없음

### TO-BE
- 모임 삭제 시 해당 모임에 참여신청한 모든 회원에게 알림 발송

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 해당 모임의 작성자가 아닐 때
![meeting_delete_fail](https://github.com/user-attachments/assets/fcc8d173-226f-4c48-8d68-fb21f60dbdc3)
- 존재하지 않는 모임일 때
![meeting-delete_fail2](https://github.com/user-attachments/assets/bbc5bf30-4983-4c3e-bbb8-af7014151786)
- 성공
![meeting-delete](https://github.com/user-attachments/assets/b6456403-e4da-4e1c-bc6f-313300153d81)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.